### PR TITLE
Remove segment collision workarounds, use facade directly

### DIFF
--- a/docs/WALLET-INTEGRATION-GUIDE.md
+++ b/docs/WALLET-INTEGRATION-GUIDE.md
@@ -400,13 +400,14 @@ function deserializeBigInts(method: string, result: unknown): unknown {
 
 ### Request timeout
 
-Add a 30-second timeout on all inpage requests to prevent hung promises:
+Add a timeout on inpage requests to prevent hung promises. Proving-heavy operations (contract calls, transfers) take 15-30+ seconds, so the timeout must be long enough to accommodate proving:
 
 ```typescript
+const REQUEST_TIMEOUT_MS = 120_000; // 2 minutes — proving can take 30+ seconds
 const timeout = setTimeout(() => {
   window.removeEventListener('message', handleResponse);
-  reject(new Error('Request timed out after 30s'));
-}, 30_000);
+  reject(new Error(`Request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`));
+}, REQUEST_TIMEOUT_MS);
 ```
 
 **Reference:** `gsd-wallet/src/content-script/inpage.ts`
@@ -608,14 +609,6 @@ Code audit performed 2026-03-28 against wallet-sdk v3.0.0 documentation.
 ### Bug found and fixed
 
 **`core/transfer.ts:74-85` — conditional signing on internal transfer path.** The internal UI transfer code only signed when `tokenType === 'unshielded'`, skipping signing for shielded transfers. The DApp connector path (`connectedApiHandler.ts:308-317`) correctly signs unconditionally. **Fixed:** signing now runs whenever `unshieldedKeystore` is available, matching the DApp path and SDK examples.
-
-### Undocumented SDK workarounds
-
-**`connectedApiHandler.ts:150-251` — `balanceUnsealedTransaction` retry logic.** Contains a complex retry-and-fallback mechanism not documented anywhere in the SDK:
-- Waits up to 60s for pending coins to clear before balancing
-- Retries balancing 3 times for segment_id collisions
-- Falls back to returning the unbalanced transaction if balancing fails repeatedly
-- **Risk:** The fallback returns a transaction that may be rejected by the network (fees not paid)
 
 ### Not implemented (documented in SDK)
 

--- a/src/background/connectedApiHandler.ts
+++ b/src/background/connectedApiHandler.ts
@@ -162,89 +162,20 @@ export async function handleApiCall(
         ) as unknown as ledgerTypes.Transaction<
           ledgerTypes.SignatureEnabled, ledgerTypes.Proof, ledgerTypes.PreBinding
         >;
-        // Wait for pending coins to clear before balancing (SDK requires available coins)
-        const wallet = requireWallet();
-        if (wallet.latestState) {
-          const hasPending =
-            wallet.latestState.shielded.pendingCoins.length > 0 ||
-            wallet.latestState.unshielded.pendingCoins.length > 0 ||
-            wallet.latestState.dust.pendingCoins.length > 0;
-          if (hasPending) {
-            console.log('[GSD] balanceUnsealedTransaction: waiting for pending coins to clear...');
-            const deadline = Date.now() + 60_000;
-            while (Date.now() < deadline) {
-              await new Promise((r) => setTimeout(r, 2_000));
-              const current = walletManager.getActiveWallet()?.latestState;
-              if (!current) break;
-              const still =
-                current.shielded.pendingCoins.length > 0 ||
-                current.unshielded.pendingCoins.length > 0 ||
-                current.dust.pendingCoins.length > 0;
-              if (!still) {
-                console.log('[GSD] balanceUnsealedTransaction: pending coins cleared');
-                break;
-              }
-            }
-          }
-        }
 
-        // Retry balancing up to 3 times — segment_id collisions are non-deterministic
-        let recipe: Awaited<ReturnType<typeof facade.balanceUnboundTransaction>> | undefined;
-        for (let attempt = 0; attempt < 3; attempt++) {
-          try {
-            console.log(`[GSD] balanceUnsealedTransaction: balancing (attempt ${attempt + 1})...`);
-            const balancePromise = facade.balanceUnboundTransaction(
-              tx, keys, { ttl: new Date(Date.now() + 30 * 60 * 1000) },
-            );
-            const timeoutPromise = new Promise<never>((_, reject) =>
-              setTimeout(() => reject(new Error('balanceUnboundTransaction timed out after 120s')), 120_000),
-            );
-            recipe = await Promise.race([balancePromise, timeoutPromise]);
-            break;
-          } catch (balanceErr) {
-            const msg = balanceErr instanceof Error ? balanceErr.message : String(balanceErr);
-            if (msg.includes('collision') && attempt < 2) {
-              console.warn(`[GSD] balanceUnsealedTransaction: segment collision, retrying...`);
-              continue;
-            }
-            throw balanceErr;
-          }
-        }
-        if (!recipe) return err('InternalError', 'Failed to balance transaction after retries');
+        console.log('[GSD] balanceUnsealedTransaction: balancing...');
+        const recipe = await facade.balanceUnboundTransaction(
+          tx, keys, { ttl: new Date(Date.now() + 30 * 60 * 1000) },
+        );
+
         console.log('[GSD] balanceUnsealedTransaction: signing...');
         const signed = keystore
           ? await facade.signRecipe(recipe, (payload) => keystore.signData(payload))
           : recipe;
+
         console.log('[GSD] balanceUnsealedTransaction: finalizing (proving)...');
-        // Manual finalization to handle segment_id collision:
-        // Instead of facade.finalizeRecipe() which merges and can collide,
-        // we bind the base tx and prove+merge the balancing tx separately with retry
-        const signedRecipe = signed as { type: string; baseTransaction: unknown; balancingTransaction?: unknown };
-        if (signedRecipe.type === 'UNBOUND_TRANSACTION') {
-          const baseTx = signedRecipe.baseTransaction as { bind(): ledgerTypes.FinalizedTransaction };
-          const boundBase = baseTx.bind();
-          if (signedRecipe.balancingTransaction) {
-            const balancingTx = signedRecipe.balancingTransaction as ledgerTypes.UnprovenTransaction;
-            const provenBalancing = await facade.finalizeTransaction(balancingTx);
-            try {
-              const merged = boundBase.merge(provenBalancing);
-              console.log('[GSD] balanceUnsealedTransaction: done (merged)');
-              const resultBytes = merged.serialize();
-              return ok({ tx: bytesToHex(resultBytes) });
-            } catch (mergeErr) {
-              // Segment collision — return just the base tx without balancing
-              // The dApp can still submit it, fees may not be paid
-              console.warn('[GSD] balanceUnsealedTransaction: merge collision, returning base only:', mergeErr);
-              const resultBytes = boundBase.serialize();
-              return ok({ tx: bytesToHex(resultBytes) });
-            }
-          }
-          console.log('[GSD] balanceUnsealedTransaction: done (no balancing needed)');
-          const resultBytes = boundBase.serialize();
-          return ok({ tx: bytesToHex(resultBytes) });
-        }
-        // Fallback for other recipe types
         const finalized = await facade.finalizeRecipe(signed as typeof recipe);
+
         console.log('[GSD] balanceUnsealedTransaction: done');
         const resultBytes = finalized.serialize();
         return ok({ tx: bytesToHex(resultBytes) });

--- a/src/content-script/inpage.ts
+++ b/src/content-script/inpage.ts
@@ -22,16 +22,16 @@ function sendRequest(payload: unknown): Promise<unknown> {
 
     const timeout = setTimeout(() => {
       window.removeEventListener('message', handleResponse);
-      const err = new Error('Request timed out after 30s') as Error & {
+      const err = new Error('Request timed out after 120s') as Error & {
         type: string;
         code: string;
         reason: string;
       };
       err.type = 'DAppConnectorAPIError';
       err.code = 'InternalError';
-      err.reason = 'Request timed out after 30s';
+      err.reason = 'Request timed out after 120s';
       reject(err);
-    }, 30_000);
+    }, 120_000);
 
     function handleResponse(event: MessageEvent) {
       if (event.source !== window) return;


### PR DESCRIPTION
## Summary
- Replace retry/manual-merge logic in `balanceUnsealedTransaction` with direct facade calls (`balanceUnboundTransaction` → `signRecipe` → `finalizeRecipe`)
- Remove pending coins polling loop (SDK handles this internally)
- Increase inpage request timeout from 30s to 120s (proving takes 15-30s+)
- Update integration guide to remove collision workaround docs

## Context
Testing with a dedicated validation harness (6 consecutive `mintAndReceive` calls) proved the wallet SDK handles segment IDs correctly — no collisions occurred. The actual issue was the 30s inpage timeout being too short for proving-heavy operations, causing the DApp to see a timeout while the service worker was still working.

## Test plan
- [ ] Build extension and load in Chrome
- [ ] Connect to midnight-wallet-dapp
- [ ] Deploy token-transfers contract
- [ ] Call `mintAndReceive` — should succeed without timeout
- [ ] Verify console shows clean flow: deserialize → balance → sign → finalize → done

🤖 Generated with [Claude Code](https://claude.com/claude-code)