### PR TITLE
Sync diagnostics, stall detection, SDK interception, docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,21 @@ Chrome extension wallet for dApp developers building on the [Midnight](https://m
 - **Shielded & unshielded transfers** — send tokens with ZK proving via server prover
 - **Dust operations** — register/deregister UTXOs for dust generation
 - **DApp connector** — `window.midnight` injection implementing the Midnight DApp connector API
-- **Debug panel** — real-time sync progress, UTXO inspection, token balances per subsystem (Dust/Shielded/Unshielded)
-- **Built-in explorer** — query the v4 indexer for transaction, block, and contract details
-- **Diagnostics** — structured event stream from the service worker with filterable log levels
 - **Custom endpoints** — override Node, Indexer, and Prover URLs per environment
+
+### Sync & diagnostics
+
+- **Non-blocking sync** — UI renders immediately while the wallet syncs in the background; no blank screens or loading spinners
+- **Per-wallet sync progress** — always-visible Shielded/Unshielded/Dust rows showing applied/total event counts with overall progress bar
+- **Sync phase in header** — current phase (Connecting/Syncing X%/Stalled/Synced) displayed next to the network selector
+- **Stall detection** — automatic detection when sync stops advancing for 30s (e.g., after WebSocket disconnect); shown as "Stalled" with warning diagnostic
+- **SDK console interception** — captures `@polkadot/api` RPC-CORE errors, WebSocket disconnects, and reconnection events that normally only appear in the browser console
+- **Persistent diagnostics** — 2000-event ring buffer persisted to `chrome.storage.session`; survives service worker restarts (Chrome kills idle SWs after ~30s)
+- **Filterable event stream** — filter by level (DBG/INF/WRN/ERR) and category (SW/Wallet/State/Sync/SDK/DApp/API/Pop/Tx/Idx/Sto/Err)
+- **Log export** — download all diagnostic events as NDJSON with ISO timestamps for sharing in bug reports
+- **Status bar** — persistent bottom bar showing the latest diagnostic event with timestamp and category
+- **Debug tabs** — real-time sync progress, UTXO inspection, token balances per subsystem (Dust/Shielded/Unshielded), transaction history
+- **Built-in explorer** — query the v4 indexer for transaction, block, and contract details
 
 ## Quick start
 
@@ -33,7 +44,7 @@ npm run build
 
 Load in Chrome: `chrome://extensions` → Developer mode → Load unpacked → select `dist/`
 
-**Recommended:** Click the expand icon (↗) in the header to open in a full browser tab. The popup works but the full-tab view gives you much more space for the debug panel, explorer, and diagnostics.
+**Recommended:** Click the expand icon in the header to open in a full browser tab. The popup works but the full-tab view gives you much more space for the debug panel, explorer, and diagnostics.
 
 ### Localnet setup
 
@@ -48,6 +59,22 @@ Load in Chrome: `chrome://extensions` → Developer mode → Load unpacked → s
 2. Select your target network (DevNet, QANet, Preview, PreProd)
 3. Import your funded wallet seed
 4. Your dApp can discover the wallet via `window.midnight`
+
+## How sync works
+
+The wallet syncs three subsystems independently:
+
+| Subsystem | What it syncs | Why |
+|-----------|--------------|-----|
+| **Shielded** | All ZSwap events on chain | Privacy — wallet filters locally so the indexer never sees your viewing keys |
+| **Unshielded** | Only your transactions | Public — indexer can filter by address without privacy risk |
+| **Dust** | All dust events on chain | Same privacy model as shielded — local filtering |
+
+**First sync is slow on mainnet** (~87k shielded + ~87k dust events). Subsequent opens restore from the SDK's cached state and only sync the delta. The unshielded subsystem syncs instantly because it only streams your transactions.
+
+The two-phase initialization ensures the UI is never blocked:
+1. **Phase 1 (fast):** Create facade, subscribe to state, emit initial zero-progress state to UI
+2. **Phase 2 (background):** `facade.start()` connects to indexer/node, sync begins; state updates flow to UI progressively
 
 ## DApp connector
 
@@ -64,7 +91,7 @@ Type a transaction hash, block height, or contract address in the search field:
 | Input | Lookup |
 |-------|--------|
 | Number (e.g. `121972`) | Block by height |
-| 64-char hex | Transaction by hash → falls back to contract |
+| 64-char hex | Transaction by hash, falls back to contract |
 
 ## Network configuration
 
@@ -92,7 +119,8 @@ Intentional trade-offs for developer convenience:
 
 ## Known issues
 
-- **Segment ID collision in DApp transaction balancing** — [#10](https://github.com/adamreynolds-io/gsd-wallet/issues/10)
+- **Mainnet sync stalls** — The mainnet RPC node (`wss://rpc.mainnet.midnight.network`) periodically drops WebSocket connections with `1000: Normal Closure`. The `@polkadot/api` SDK reconnects automatically but sync can stall. The wallet detects this after 30s and shows "Stalled". Closing and reopening the popup triggers a fresh connection. This is a mainnet infrastructure issue, not a wallet bug.
+- **First mainnet sync takes minutes** — ~87k shielded + ~87k dust events must be downloaded and processed client-side. This is by design for privacy (see "How sync works" above).
 
 ## Documentation
 

--- a/docs/WALLET-INTEGRATION-GUIDE.md
+++ b/docs/WALLET-INTEGRATION-GUIDE.md
@@ -558,7 +558,65 @@ A wallet showing NIGHT=0 with contract tokens present is **correct behavior, not
 
 ---
 
-## 9. Common Failure Modes
+## 9. Diagnostic System
+
+Building a wallet on the Midnight SDK requires deep observability. The SDK uses `@polkadot/api` internally which logs critical events (WebSocket disconnects, RPC errors) only to `console.warn/error`. Service workers can be killed by Chrome at any time, losing all in-memory state. The diagnostic system addresses both problems.
+
+### Architecture
+
+```
+SDK (@polkadot/api) ──console.warn/error──→ sdkConsoleInterceptor ──emit()──→ diagnosticLogger
+                                                                                    │
+walletManager ──emit()──→ diagnosticLogger ←──rehydrate()── chrome.storage.session  │
+                                │                                                    │
+                                ├── in-memory buffer (2000 events, real-time)        │
+                                ├── chrome.storage.session (persists across SW kills) │
+                                └── port broadcast ──→ popup DiagnosticsPanel        │
+                                                          ├── filterable by level/category
+                                                          └── NDJSON export
+```
+
+### Event categories
+
+| Category | What it captures |
+|----------|-----------------|
+| `sw` | Service worker lifecycle (start, install, restart) |
+| `wallet` | Facade init, key derivation, start/stop, timing |
+| `state` | Sync status transitions (initializing → syncing → synced) |
+| `sync` | Per-wallet progress (applied/total every 2s), connection changes, phase transitions, stall detection |
+| `sdk` | Intercepted SDK console output (RPC-CORE disconnects, WebSocket errors, @polkadot internals) |
+| `dapp` | DApp connect/disconnect, API method calls |
+| `api` | DApp API handler results |
+| `tx` | Transaction phases (balance, sign, prove, submit) |
+| `indexer` | GraphQL queries |
+| `error` | Errors at any layer |
+
+### Persistence
+
+Events are persisted to `chrome.storage.session` via debounced writes (500ms or every 10 events). On SW startup, `rehydrate()` restores the buffer. This survives Chrome's aggressive SW lifecycle (kill after ~30s idle). Events are cleared when the browser closes, which is appropriate for diagnostic data.
+
+Each SW lifecycle gets a unique `sessionId` (UUID) — visible in the "Service worker started" event — so you can identify restarts in the event stream.
+
+### Stall detection
+
+An independent `setInterval` (10s) checks whether the combined applied count across all three wallets has advanced in the last 30 seconds. This runs outside the RxJS subscription, so it detects stalls even when the SDK's state observable stops emitting (e.g., after a WebSocket disconnect kills the underlying data stream).
+
+When a stall is detected:
+- `syncPhase` is set to `'stalled'` and broadcast to the popup
+- A `warn` level `sync` event is emitted with per-wallet progress data
+- The header badge shows "Stalled"
+
+### Why shielded/dust sync is slow
+
+The indexer streams **all** ZSwap (shielded) and dust events on the chain, not just those belonging to the wallet. This is a privacy design choice: if the indexer filtered by viewing keys, it would learn which addresses belong to the wallet, breaking the privacy model. The wallet receives all events and filters locally.
+
+Unshielded transactions are public and can be filtered server-side, so they sync instantly.
+
+On mainnet with ~87k shielded and ~87k dust events, first sync takes several minutes. Subsequent opens should restore from cached state and only sync the delta.
+
+---
+
+## 10. Common Failure Modes
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
@@ -578,7 +636,7 @@ A wallet showing NIGHT=0 with contract tokens present is **correct behavior, not
 
 ---
 
-## 10. Documentation Gap Analysis
+## 11. Documentation Gap Analysis
 
 What the existing Midnight documentation covers vs what you actually need:
 
@@ -603,7 +661,7 @@ What the existing Midnight documentation covers vs what you actually need:
 
 ---
 
-## 11. Reference Implementation
+## 12. Reference Implementation
 
 The GSD Wallet provides working implementations of every pattern in this guide:
 
@@ -613,10 +671,13 @@ The GSD Wallet provides working implementations of every pattern in this guide:
 | Facade initialization (two-phase) | `src/background/walletManager.ts` | `initializeWalletCore()` — Phase 1: subscribe + emit initial state; Phase 2: `facade.start()` in background |
 | SW race condition guard | `src/background/walletManager.ts` | `waitForReady()` |
 | State serialization | `src/background/walletManager.ts` | `serializeState()` |
-| Per-wallet sync progress | `src/popup/pages/Dashboard.tsx` | `MiniSyncBar` — three bars showing applied/total per wallet |
+| Per-wallet sync progress | `src/popup/pages/Dashboard.tsx` | `SyncDetailRow` — always-visible rows showing applied/total per wallet |
+| Sync stall detection | `src/background/walletManager.ts` | Independent timer detects 30s of no progress, broadcasts `stalled` phase |
 | Granular sync diagnostics | `src/background/walletManager.ts` | `sync:phase`, `sync:connected`, `sync:progress` events |
-| Diagnostic event logger | `src/background/diagnosticLogger.ts` | `emit()`, `getBacklog()`, `onEvent()` |
+| Persistent diagnostic logger | `src/background/diagnosticLogger.ts` | `emit()`, `rehydrate()` — 2000-event ring buffer persisted to `chrome.storage.session` |
+| SDK console interception | `src/background/sdkConsoleInterceptor.ts` | Captures `@polkadot/api` RPC-CORE errors and WebSocket disconnects |
 | Diagnostic event broadcasting | `src/background/messageRouter.ts` | `onEvent` → `DIAGNOSTIC_EVENT` to ports |
+| Log export | `src/popup/components/DiagnosticsPanel.tsx` | `downloadLogs()` — NDJSON export with ISO timestamps |
 | Message protocol types | `src/shared/messages.ts` | `PopupRequest`, `PopupResponse` |
 | DApp connector (inpage) | `src/content-script/inpage.ts` | Full file (120s timeout) |
 | Content script bridge | `src/content-script/content-script.ts` | Full file |
@@ -632,7 +693,7 @@ Repository: `https://github.com/adamreynolds-io/gsd-wallet`
 
 ---
 
-## 12. Audit Findings (GSD Wallet v0.1.0)
+## 13. Audit Findings (GSD Wallet v0.1.0)
 
 Code audit performed 2026-03-28 against wallet-sdk v3.0.0 documentation.
 


### PR DESCRIPTION
## Summary

- Non-blocking wallet initialization: UI renders immediately, sync runs in background
- Per-wallet sync progress rows (Shielded/Unshielded/Dust) always visible with applied/total event counts
- Sync phase badge in header bar (Connecting/Syncing X%/Stalled/Synced)
- Stall detection: independent 10s timer detects 30s of no progress even when SDK observable stops
- SDK console interception: captures @polkadot/api RPC-CORE errors and WebSocket disconnects
- Persistent diagnostics: 2000-event ring buffer in chrome.storage.session survives SW restarts
- NDJSON log export with ISO timestamps for bug report sharing
- New `sdk` and `sync` diagnostic categories
- Fix network switch dropping messages (dedicated non-broadcast port)
- Fix environment default showing 'dev' instead of actual stored environment
- README: new "How sync works" section explaining privacy-driven indexer streaming model
- Integration guide: new section 9 covering full diagnostic system architecture

## Test plan

- [ ] Open wallet — Dashboard renders immediately with empty state, sync bars at 0/0
- [ ] Mainnet sync — progress rows fill independently; header shows "Syncing 54%"
- [ ] When synced — rows show "87.2k synced"; header shows "Synced"
- [ ] Kill SW (wait 30s idle) — reopen popup, backlog events from before the kill appear
- [ ] SDK disconnect (mainnet RPC) — orange SDK events appear in diagnostics panel
- [ ] Stall detection — after 30s no progress, "Stalled" appears in header + warning event
- [ ] Download logs — NDJSON file with ISO timestamps
- [ ] Switch network — correct env shown, navigates to onboarding if no wallet for that env

🤖 Generated with [Claude Code](https://claude.com/claude-code)