### PR TITLE
Live popup sync updates, combined totals, fix synced label

### DIFF
--- a/src/popup/hooks/useWalletState.ts
+++ b/src/popup/hooks/useWalletState.ts
@@ -21,6 +21,7 @@ function handleMessage(msg: PopupResponse): void {
 export function useWalletConnection(): void {
   const portRef = useRef<chrome.runtime.Port | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const unmounted = useRef(false);
 
   useEffect(() => {
@@ -37,6 +38,10 @@ export function useWalletConnection(): void {
 
       port.onDisconnect.addListener(() => {
         portRef.current = null;
+        if (pollTimer.current) {
+          clearInterval(pollTimer.current);
+          pollTimer.current = null;
+        }
         store.addDiagnosticEvent({
           id: Date.now(),
           timestamp: Date.now(),
@@ -68,6 +73,16 @@ export function useWalletConnection(): void {
 
       port.postMessage({ type: 'GET_STATE' });
       port.postMessage({ type: 'GET_DIAGNOSTIC_BACKLOG' });
+
+      // Poll for state every 2s as a fallback for broadcast delivery issues
+      if (pollTimer.current) clearInterval(pollTimer.current);
+      pollTimer.current = setInterval(() => {
+        try {
+          port.postMessage({ type: 'GET_STATE' });
+        } catch {
+          // Port dead — reconnect will handle it
+        }
+      }, 2000);
     }
 
     // Check if wallets exist
@@ -103,6 +118,9 @@ export function useWalletConnection(): void {
       unmounted.current = true;
       if (reconnectTimer.current) {
         clearTimeout(reconnectTimer.current);
+      }
+      if (pollTimer.current) {
+        clearInterval(pollTimer.current);
       }
       if (portRef.current) {
         portRef.current.disconnect();

--- a/src/popup/pages/Dashboard.tsx
+++ b/src/popup/pages/Dashboard.tsx
@@ -380,16 +380,20 @@ function TokenRows({ label, balances }: { label: string; balances: Record<string
 
 /* ── Debug tabs ── */
 
-function SyncRow({ progress, percent }: { progress: SyncProgress; percent: number }) {
+function SyncRow({ state }: { state: SerializedWalletState }) {
+  const totalApplied = state.shielded.progress.applied + state.unshielded.progress.applied + state.dust.progress.applied;
+  const totalHighest = state.shielded.progress.highest + state.unshielded.progress.highest + state.dust.progress.highest;
+  const allConnected = state.shielded.progress.connected && state.unshielded.progress.connected && state.dust.progress.connected;
+  const percent = state.overallSyncPercent;
   return (
     <div className="mb-1.5">
       <div className="flex justify-between text-xs text-gray-500 mb-0.5">
-        <span>{progress.connected ? 'Connected' : 'Disconnected'}</span>
-        <span>{progress.applied} / {progress.highest} ({percent}%)</span>
+        <span>{allConnected ? 'Connected' : 'Disconnected'}</span>
+        <span>{totalApplied.toLocaleString()} / {totalHighest.toLocaleString()} ({percent}%)</span>
       </div>
       <div className="w-full h-1 bg-midnight-900 rounded-full overflow-hidden">
         <div
-          className={`h-full rounded-full transition-[width] duration-300 ${progress.connected ? 'bg-gradient-to-r from-accent-purple to-accent-magenta' : 'bg-gray-600'}`}
+          className={`h-full rounded-full transition-[width] duration-300 ${allConnected ? 'bg-gradient-to-r from-accent-purple to-accent-magenta' : 'bg-gray-600'}`}
           style={{ width: `${percent}%` }}
         />
       </div>
@@ -415,7 +419,7 @@ function DustDebug({ state }: {
 }) {
   return (
     <div className="space-y-1">
-      <SyncRow progress={state.dust.progress} percent={state.dust.syncPercent} />
+      <SyncRow state={state} />
       <KV k="Balance" v={formatLargeNumber(BigInt(state.dust.balance), DUST_DENOMINATION)} />
       <KV k="Address" v={trunc(state.dust.address)} />
       <Divider label={`UTXOs (${state.unshielded.utxos.length})`} />
@@ -428,7 +432,7 @@ function ShieldedDebug({ state }: { state: SerializedWalletState }) {
   const entries = Object.entries(state.shielded.balances);
   return (
     <div className="space-y-1">
-      <SyncRow progress={state.shielded.progress} percent={state.shielded.syncPercent} />
+      <SyncRow state={state} />
       <KV k="Coins" v={String(state.shielded.coinCount)} />
       <Divider label="Balances" />
       {entries.length === 0 ? (
@@ -451,7 +455,7 @@ function UnshieldedDebug({ state }: {
   const unreg = state.unshielded.utxos.filter((u) => !u.registered);
   return (
     <div className="space-y-1">
-      <SyncRow progress={state.unshielded.progress} percent={state.unshielded.syncPercent} />
+      <SyncRow state={state} />
       <KV k="UTXOs" v={String(state.unshielded.utxos.length)} />
       <KV k="Registered" v={`${reg.length} / ${state.unshielded.utxos.length}`} />
       <KV k="Unregistered" v={String(unreg.length)} />
@@ -656,7 +660,7 @@ function SyncDetailRow({ label, color, progress, percent }: {
   progress: SyncProgress;
   percent: number;
 }) {
-  const done = progress.highest > 0 && progress.applied >= progress.highest;
+  const done = percent === 100 && progress.highest > 0 && progress.applied >= progress.highest;
   return (
     <div
       className="flex items-center justify-between text-xs"


### PR DESCRIPTION
## Summary

- Poll SW for state every 2s so popup updates live (no close/reopen needed)
- Debug tab sync bar shows combined total across all 3 wallets (e.g., 114,901 / 174,686)
- Fix "synced" label showing prematurely when applied > highest during early sync

## Test plan

- [ ] Open popup during mainnet sync — numbers update live every 2s
- [ ] Check debug tab (Dust/Shielded/Unshielded) — Connected bar shows combined total
- [ ] During sync, no wallet row shows "synced" until that wallet is actually at 100%
- [ ] After full sync, all rows show "87.2k synced" correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)