### PR TITLE
Fix overall sync percentage calculation

### DIFF
--- a/src/background/walletManager.ts
+++ b/src/background/walletManager.ts
@@ -155,9 +155,13 @@ function serializeState(
     : (Number(dp.appliedIndex) / Number(dp.highestRelevantWalletIndex)) * 100;
 
   const allConnected = sp.isConnected && up.isConnected && dp.isConnected;
-  const overallSyncPercent = Math.floor(
-    (shieldedPercent + unshieldedPercent + dustPercent) / 3,
-  );
+  const totalApplied =
+    Number(sp.appliedIndex) + Number(up.appliedId) + Number(dp.appliedIndex);
+  const totalHighest =
+    Number(sp.highestRelevantWalletIndex) + Number(up.highestTransactionId) + Number(dp.highestRelevantWalletIndex);
+  const overallSyncPercent = totalHighest > 0
+    ? Math.floor((totalApplied / totalHighest) * 100)
+    : (allConnected ? 100 : 0);
   const reallySynced = facadeState.isSynced || (allConnected && shieldedSynced && unshieldedSynced && dustSynced);
 
   let dustBal = 0n;

--- a/src/popup/pages/Dashboard.tsx
+++ b/src/popup/pages/Dashboard.tsx
@@ -384,7 +384,7 @@ function SyncRow({ state }: { state: SerializedWalletState }) {
   const totalApplied = state.shielded.progress.applied + state.unshielded.progress.applied + state.dust.progress.applied;
   const totalHighest = state.shielded.progress.highest + state.unshielded.progress.highest + state.dust.progress.highest;
   const allConnected = state.shielded.progress.connected && state.unshielded.progress.connected && state.dust.progress.connected;
-  const percent = state.overallSyncPercent;
+  const percent = totalHighest > 0 ? Math.floor((totalApplied / totalHighest) * 100) : 0;
   return (
     <div className="mb-1.5">
       <div className="flex justify-between text-xs text-gray-500 mb-0.5">


### PR DESCRIPTION
## Summary

Fix `overallSyncPercent` to use `totalApplied / totalHighest` instead of averaging three percentages. The old formula `(shielded% + unshielded% + dust%) / 3` inflated the result — e.g., showing 61% when actual progress was 43% (75k/174k events).

Affects header badge, main progress bar, and debug tab sync bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)