### PR TITLE
Disclaimer gate, GitHub link, integration guide update

### DIFF
--- a/docs/WALLET-INTEGRATION-GUIDE.md
+++ b/docs/WALLET-INTEGRATION-GUIDE.md
@@ -229,14 +229,49 @@ Without `wasm-unsafe-eval`, the ledger WASM module will fail to instantiate with
 
 #### Service worker keepalive
 
-Chrome terminates idle service workers after ~30 seconds. The wallet needs to stay alive during sync:
+Chrome terminates idle service workers after ~30 seconds. WebSocket connections (used by `@polkadot/api` for node/indexer communication) do NOT count as activity — Chrome will kill the SW even with active WebSockets.
+
+**Alarms alone are insufficient.** Chrome's minimum alarm period is 30 seconds, and the alarm handler runs too fast to extend the SW lifetime meaningfully.
+
+**Solution: Offscreen document with persistent port.** Create an offscreen document that holds a persistent port to the service worker. Chrome keeps the SW alive as long as a connected port exists:
 
 ```typescript
-chrome.alarms.create('gsd-keepalive', { periodInMinutes: 0.4 });
-chrome.alarms.onAlarm.addListener(() => { /* no-op */ });
+// offscreen.ts — persistent keepalive port
+function connectKeepalive() {
+  const port = chrome.runtime.connect({ name: 'gsd-keepalive' });
+  port.onDisconnect.addListener(() => {
+    // SW died — reconnect to force restart
+    setTimeout(connectKeepalive, 500);
+  });
+}
+connectKeepalive();
 ```
 
-Clear the alarm when the wallet is stopped.
+```typescript
+// messageRouter.ts — accept the keepalive port without broadcasting
+if (port.name === 'gsd-keepalive') {
+  return; // Just hold it open
+}
+```
+
+```typescript
+// walletManager.ts — create the offscreen document when wallet starts
+async function ensureOffscreenDocument(): Promise<void> {
+  const contexts = await chrome.runtime.getContexts({
+    contextTypes: ['OFFSCREEN_DOCUMENT' as chrome.runtime.ContextType],
+  });
+  if (contexts.length > 0) return;
+  await chrome.offscreen.createDocument({
+    url: 'src/offscreen/offscreen.html',
+    reasons: ['WORKERS' as chrome.offscreen.Reason],
+    justification: 'Keep service worker alive during wallet sync',
+  });
+}
+```
+
+Without this, mainnet sync (~87k shielded + ~87k dust events, ~6 minutes) will never complete — Chrome kills the SW every ~60 seconds and the SDK restarts from scratch each time.
+
+**Reference:** `gsd-wallet/src/offscreen/offscreen.ts`, `gsd-wallet/src/background/walletManager.ts:ensureOffscreenDocument`
 
 #### Popup height limit
 
@@ -260,6 +295,50 @@ for (const [tokenId, amount] of Object.entries(facadeState.unshielded.balances))
 // Popup → display
 const value = BigInt(balances[tokenId]);
 ```
+
+#### Live state updates via chrome.storage.onChanged
+
+Chrome MV3 port message delivery (`port.postMessage`) is unreliable for long-lived connections. Messages sent by the service worker may silently fail to reach the popup, especially after reconnections. **Do not rely on port broadcasts alone for live UI updates.**
+
+**Solution: Dual-channel updates.** The service worker writes state to `chrome.storage.session` on every update. The popup watches for changes via `chrome.storage.onChanged`:
+
+```typescript
+// Service worker — writes on every state change (already happening for caching)
+chrome.storage.session.set({ gsdLastState: serializedState });
+
+// Popup — watches for changes (bulletproof, no port dependency)
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== 'session') return;
+  if (changes['gsdLastState']?.newValue) {
+    store.setWalletState(changes['gsdLastState'].newValue);
+  }
+  if (changes['gsdDiagnosticEvents']?.newValue) {
+    store.addDiagnosticEventsBatch(changes['gsdDiagnosticEvents'].newValue);
+  }
+});
+```
+
+This works across all open popup/tab instances simultaneously and is immune to port lifecycle issues.
+
+**Reference:** `gsd-wallet/src/popup/hooks/useWalletState.ts`
+
+#### Disclaimer gate for DApp requests
+
+If your wallet includes a disclaimer or terms-of-use gate, ensure DApp API requests are also blocked — not just the popup UI. The service worker must independently check the disclaimer state before processing any DApp request:
+
+```typescript
+async function handleDappRequest(payload, origin) {
+  const result = await chrome.storage.local.get('gsdDisclaimerAccepted');
+  if (result['gsdDisclaimerAccepted'] !== true) {
+    return { type: 'GSD_ERROR', error: { code: 'NotReady', reason: 'Disclaimer not accepted' } };
+  }
+  // ... handle request
+}
+```
+
+Store the disclaimer acceptance in `chrome.storage.local` (persists across browser restarts), not `session`.
+
+**Reference:** `gsd-wallet/src/background/messageRouter.ts:isDisclaimerAccepted`, `gsd-wallet/src/popup/App.tsx:Disclaimer`
 
 ### Electron
 
@@ -571,9 +650,9 @@ walletManager ──emit()──→ diagnosticLogger ←──rehydrate()── 
                                 │                                                    │
                                 ├── in-memory buffer (2000 events, real-time)        │
                                 ├── chrome.storage.session (persists across SW kills) │
-                                └── port broadcast ──→ popup DiagnosticsPanel        │
+                                └── storage.onChanged ──→ popup DiagnosticsPanel     │
                                                           ├── filterable by level/category
-                                                          └── NDJSON export
+                                                          └── NDJSON export with ISO timestamps
 ```
 
 ### Event categories
@@ -606,6 +685,47 @@ When a stall is detected:
 - A `warn` level `sync` event is emitted with per-wallet progress data
 - The header badge shows "Stalled"
 
+### SDK console interception
+
+The `@polkadot/api` library logs critical events (WebSocket disconnects, RPC errors, reconnections) only to `console.warn/error`. In a service worker, these are invisible unless DevTools is open. Monkey-patch `console.warn` and `console.error` before any SDK imports to capture these as structured diagnostic events:
+
+```typescript
+// Must be called BEFORE setupMessageRouter() or any SDK imports
+const originalWarn = console.warn;
+console.warn = (...args: unknown[]) => {
+  originalWarn.apply(console, args);
+  const message = args.map(String).join(' ');
+  if (isSdkMessage(message)) {
+    emit('warn', 'sdk', message);
+  }
+};
+
+function isSdkMessage(msg: string): boolean {
+  return msg.includes('RPC-CORE') || msg.includes('disconnected from') ||
+    msg.includes('WebSocket') || msg.includes('@polkadot');
+}
+```
+
+This captures errors like `RPC-CORE: subscribeRuntimeVersion(): disconnected from wss://rpc.mainnet.midnight.network/: 1000:: Normal Closure` which are invisible in every other Midnight wallet.
+
+**Reference:** `gsd-wallet/src/background/sdkConsoleInterceptor.ts`
+
+### Diagnostic event flush timing
+
+Events are flushed to `chrome.storage.session` after 100ms or 3 accumulated events, whichever comes first. This provides near-instant delivery to the popup via `chrome.storage.onChanged` while batching writes to avoid overwhelming storage I/O.
+
+On service worker startup, `rehydrate()` restores persisted events from the previous lifecycle and continues the `nextId` counter so event IDs are monotonically increasing across restarts. Each lifecycle gets a unique `sessionId` (UUID) visible in the "Service worker started" event, so restarts are identifiable in the log.
+
+### Calculating overall sync percentage
+
+Do NOT average per-wallet percentages — this inflates the result because unshielded (374 events at 100%) gets equal weight to shielded (87k events at 40%). Instead, sum applied and highest across all wallets:
+
+```typescript
+const totalApplied = shielded.applied + unshielded.applied + dust.applied;
+const totalHighest = shielded.highest + unshielded.highest + dust.highest;
+const overallPercent = totalHighest > 0 ? Math.floor((totalApplied / totalHighest) * 100) : 0;
+```
+
 ### Why shielded/dust sync is slow
 
 The indexer streams **all** ZSwap (shielded) and dust events on the chain, not just those belonging to the wallet. This is a privacy design choice: if the indexer filtered by viewing keys, it would learn which addresses belong to the wallet, breaking the privacy model. The wallet receives all events and filters locally.
@@ -626,8 +746,12 @@ On mainnet with ~87k shielded and ~87k dust events, first sync takes several min
 | Address shows as empty string | `MidnightBech32m.encode()` threw (address not yet synced) | Wrap in try-catch, show placeholder |
 | UTXO hash "Not found in indexer" | `intentHash` is not a transaction hash | Don't use intent hash as indexer lookup key |
 | Popup scrolls past bottom | Chrome enforces viewport height limit (~600px) | Cap popup height; offer "Open in Full Tab" |
-| Service worker dies mid-operation | Chrome kills idle SWs after ~30s | Use `chrome.alarms` keepalive + persistent ports |
+| Service worker dies mid-sync | Chrome kills idle SWs after ~30s; WebSockets don't count as activity | Use offscreen document with persistent port (not alarms alone) |
+| Sync restarts from 0 on every SW restart | `InMemoryTransactionHistoryStorage` loses all state | Offscreen keepalive prevents kills; persistent SDK storage adapter is the long-term fix |
+| Popup shows stale data after close/reopen | Port message delivery unreliable in MV3 | Use `chrome.storage.onChanged` for live updates instead of port broadcasts |
+| Sync percentage inflated (61% shown, actual 43%) | Averaging per-wallet percentages equally | Use `totalApplied / totalHighest` across all wallets |
 | API call hangs after SW restart | `autoUnlock` reinitializes facade while API handler uses old ref | Gate API handlers with `waitForReady()` before using facade |
+| DApp connects before user accepts disclaimer | Popup gate doesn't block service worker DApp handler | Check disclaimer in both popup AND DApp request handler independently |
 | `balanceUnboundTransaction` hangs | Facade balance method blocks indefinitely for some contract txs | Under investigation — diagnostics panel helps trace the exact stall point |
 | `HDWallet.fromSeed` returns but wallet fails later | Didn't check `.type === 'seedOk'` | Always check tagged return types |
 | Facade created but never syncs | Forgot to call `facade.start()` after `init()` | `.init()` and `.start()` are separate steps |

--- a/src/background/messageRouter.ts
+++ b/src/background/messageRouter.ts
@@ -110,11 +110,23 @@ export function setupMessageRouter(): void {
     }
   }, 60_000);
 
+  async function isDisclaimerAccepted(): Promise<boolean> {
+    const result = await chrome.storage.local.get('gsdDisclaimerAccepted');
+    return result['gsdDisclaimerAccepted'] === true;
+  }
+
   // Shared dApp request handler (used by both port and one-shot messages)
   async function handleDappRequest(
     payload: Record<string, unknown>,
     origin: string,
   ): Promise<unknown> {
+    if (!(await isDisclaimerAccepted())) {
+      return {
+        type: 'GSD_ERROR',
+        error: { code: 'NotReady', reason: 'Wallet disclaimer has not been accepted. Open the wallet popup first.' },
+      };
+    }
+
     if (payload['type'] === 'GSD_CONNECT') {
       const sessionId = crypto.randomUUID();
       sessions.set(sessionId, {

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,5 +1,5 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Header } from '@popup/components/Header';
 import { Unlock } from '@popup/pages/Unlock';
 import { Onboarding } from '@popup/pages/Onboarding';
@@ -8,11 +8,14 @@ import { Settings } from '@popup/pages/Settings';
 import { usePopupStore } from '@popup/store/popupStore';
 import { useWalletConnection } from '@popup/hooks/useWalletState';
 
+const DISCLAIMER_KEY = 'gsdDisclaimerAccepted';
+
 export function App() {
   useWalletConnection();
 
   const status = usePopupStore((s) => s.status);
   const hasVault = usePopupStore((s) => s.hasVault);
+  const [disclaimerAccepted, setDisclaimerAccepted] = useState<boolean | null>(null);
 
   useEffect(() => {
     if (window.innerWidth > 800) {
@@ -22,6 +25,21 @@ export function App() {
       document.body.style.margin = '0 auto';
     }
   }, []);
+
+  useEffect(() => {
+    chrome.storage.local.get(DISCLAIMER_KEY).then((result) => {
+      setDisclaimerAccepted(result[DISCLAIMER_KEY] === true);
+    });
+  }, []);
+
+  if (disclaimerAccepted === null) return null;
+
+  if (!disclaimerAccepted) {
+    return <Disclaimer onAccept={() => {
+      chrome.storage.local.set({ [DISCLAIMER_KEY]: true });
+      setDisclaimerAccepted(true);
+    }} />;
+  }
 
   return (
     <div className="flex flex-col h-full">
@@ -38,6 +56,49 @@ export function App() {
           <Route path="/settings" element={<Settings />} />
         </Routes>
       </main>
+    </div>
+  );
+}
+
+function Disclaimer({ onAccept }: { onAccept: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full bg-midnight-900 p-6">
+      <div className="max-w-lg w-full bg-midnight-800 border border-midnight-500 rounded-lg p-6 space-y-4">
+        <div className="flex items-center gap-2">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+            <line x1="12" y1="9" x2="12" y2="13" /><line x1="12" y1="17" x2="12.01" y2="17" />
+          </svg>
+          <h1 className="text-lg font-bold text-white">Development Wallet</h1>
+        </div>
+
+        <div className="text-sm text-gray-300 space-y-3">
+          <p>
+            <strong className="text-amber-400">Midnight GSD is a developer tool, not a production wallet.</strong>
+          </p>
+          <p>
+            By using this wallet you acknowledge and agree that:
+          </p>
+          <ul className="list-disc list-inside space-y-1.5 text-gray-400">
+            <li>Seed phrases and private keys are stored <strong className="text-red-400">unencrypted</strong> in browser storage</li>
+            <li>This wallet is intended solely for <strong className="text-white">development, testing, and debugging</strong> on Midnight networks</li>
+            <li>You should <strong className="text-red-400">never</strong> import a seed phrase that controls real funds or mainnet assets of value</li>
+            <li>DApp connections are auto-approved without user confirmation</li>
+            <li>No security audit has been performed on this software</li>
+          </ul>
+          <p className="text-gray-500 text-xs">
+            The authors accept no liability for any loss of funds resulting from the use of this wallet.
+            Use at your own risk.
+          </p>
+        </div>
+
+        <button
+          onClick={onAccept}
+          className="w-full py-2.5 px-4 bg-amber-600 hover:bg-amber-500 text-white font-medium rounded transition-colors"
+        >
+          I understand — this is a development wallet only
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/popup/components/Header.tsx
+++ b/src/popup/components/Header.tsx
@@ -167,6 +167,15 @@ export function Header() {
           </select>
         )}
 
+        <a
+          href="https://github.com/adamreynolds-io/gsd-wallet"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="p-1.5 rounded hover:bg-midnight-600 transition-colors text-gray-400 hover:text-white"
+          title="GitHub — source code, docs, raise issues"
+        >
+          <GitHubIcon />
+        </a>
         <button
           onClick={() => {
             chrome.tabs.create({ url: chrome.runtime.getURL('src/popup/index.html') });
@@ -188,6 +197,14 @@ export function Header() {
         )}
       </div>
     </header>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z" />
+    </svg>
   );
 }
 


### PR DESCRIPTION
## Summary

- One-time disclaimer modal — blocks both popup UI and DApp API requests until accepted
- GitHub icon + link in header
- Integration guide comprehensively updated with all lessons learned from mainnet sync debugging:
  offscreen keepalive, storage-based live updates, SDK console interception, flush timing,
  sync percentage calculation, disclaimer patterns, 6 new failure modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)