### PR TITLE
Persist SDK state to IndexedDB for SW restart resilience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **gsd-wallet** (254 symbols, 578 relationships, 16 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **gsd-wallet** (421 symbols, 917 relationships, 27 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **gsd-wallet** (254 symbols, 578 relationships, 16 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **gsd-wallet** (421 symbols, 917 relationships, 27 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/README.md
+++ b/README.md
@@ -70,11 +70,13 @@ The wallet syncs three subsystems independently:
 | **Unshielded** | Only your transactions | Public — indexer can filter by address without privacy risk |
 | **Dust** | All dust events on chain | Same privacy model as shielded — local filtering |
 
-**First sync is slow on mainnet** (~87k shielded + ~87k dust events). Subsequent opens restore from the SDK's cached state and only sync the delta. The unshielded subsystem syncs instantly because it only streams your transactions.
+**First sync is slow on mainnet** (~87k shielded + ~87k dust events). The unshielded subsystem syncs instantly because it only streams your transactions.
+
+**Persistent SDK storage** ensures sync survives Chrome's service worker lifecycle. The wallet serializes SDK state to IndexedDB every 30 seconds during sync. When Chrome kills the service worker (after ~30s idle), the next restart restores from the last checkpoint and continues syncing — no progress is lost. Full mainnet sync completes across multiple SW restarts without the user needing to keep the popup open.
 
 The two-phase initialization ensures the UI is never blocked:
-1. **Phase 1 (fast):** Create facade, subscribe to state, emit initial zero-progress state to UI
-2. **Phase 2 (background):** `facade.start()` connects to indexer/node, sync begins; state updates flow to UI progressively
+1. **Phase 1 (fast):** Load checkpoint from IndexedDB (if available), create facade with restored or fresh state, subscribe to state, emit initial state to UI
+2. **Phase 2 (background):** `facade.start()` connects to indexer/node, sync resumes from checkpoint offset; state updates flow to UI progressively
 
 ## DApp connector
 
@@ -120,7 +122,7 @@ Intentional trade-offs for developer convenience:
 ## Known issues
 
 - **Mainnet sync stalls** — The mainnet RPC node (`wss://rpc.mainnet.midnight.network`) periodically drops WebSocket connections with `1000: Normal Closure`. The `@polkadot/api` SDK reconnects automatically but sync can stall. The wallet detects this after 30s and shows "Stalled". Closing and reopening the popup triggers a fresh connection. This is a mainnet infrastructure issue, not a wallet bug.
-- **First mainnet sync takes minutes** — ~87k shielded + ~87k dust events must be downloaded and processed client-side. This is by design for privacy (see "How sync works" above).
+- **First mainnet sync takes minutes** — ~87k shielded + ~87k dust events must be downloaded and processed client-side. This is by design for privacy (see "How sync works" above). Persistent SDK storage ensures sync completes across service worker restarts.
 
 ## Documentation
 
@@ -142,7 +144,7 @@ Intentional trade-offs for developer convenience:
 |---|---|
 | Midnight SDK | `wallet-sdk-facade`, `wallet-sdk-hd`, `ledger-v8`, `dapp-connector-api` |
 | UI | React 18, React Router 7, Zustand 5, TailwindCSS 3 |
-| Storage | `idb` (IndexedDB), RxJS 7 |
+| Storage | `idb` (IndexedDB — persistent SDK state, vault, tx history, permissions), RxJS 7 |
 | Build | Vite 6, `@crxjs/vite-plugin`, TypeScript 5.9 |
 | Crypto | `@scure/bip39` |
 

--- a/docs/WALLET-INTEGRATION-GUIDE.md
+++ b/docs/WALLET-INTEGRATION-GUIDE.md
@@ -22,7 +22,7 @@ Before writing code, determine your integration target:
 
 | Platform | Polyfills needed | Storage | DApp Connector | WASM CSP |
 |----------|-----------------|---------|----------------|----------|
-| **Chrome Extension (MV3)** | Buffer, assert, DOM shims | IndexedDB + chrome.storage.session | Yes (content script + inpage injection) | `wasm-unsafe-eval` in manifest |
+| **Chrome Extension (MV3)** | Buffer, assert, DOM shims | IndexedDB (persistent SDK state + app data) + chrome.storage.session (transient) | Yes (content script + inpage injection) | `wasm-unsafe-eval` in manifest |
 | **Electron** | None (has Node.js) | Filesystem or IndexedDB | Optional (BrowserWindow injection) | None (Node.js context) |
 | **Node.js (headless)** | None | Filesystem | No | None |
 | **React Native** | **NOT SUPPORTED** | — | — | — |
@@ -227,51 +227,68 @@ These must be at the TOP of your service worker entry point, before any SDK impo
 
 Without `wasm-unsafe-eval`, the ledger WASM module will fail to instantiate with no useful error message.
 
-#### Service worker keepalive
+#### Service worker lifecycle and persistent SDK storage
 
 Chrome terminates idle service workers after ~30 seconds. WebSocket connections (used by `@polkadot/api` for node/indexer communication) do NOT count as activity — Chrome will kill the SW even with active WebSockets.
 
-**Alarms alone are insufficient.** Chrome's minimum alarm period is 30 seconds, and the alarm handler runs too fast to extend the SW lifetime meaningfully.
+**What does NOT keep the SW alive:**
+- Offscreen document with persistent port — tested: SW still dies at ~60s
+- `chrome.alarms` — minimum 30s period, handler runs too fast to extend lifetime
+- `setInterval` in SW — does not prevent termination
+- `chrome.storage.session` writes — periodic writes don't prevent kills
+- Active WebSocket connections — Chrome ignores these for SW lifecycle
 
-**Solution: Offscreen document with persistent port.** Create an offscreen document that holds a persistent port to the service worker. Chrome keeps the SW alive as long as a connected port exists:
+**What DOES keep the SW alive:**
+- Popup or full-tab extension page open with active port
+- DevTools inspector attached (dev-only, not a user solution)
+
+**The real fix: Persistent SDK storage.** Instead of fighting the SW lifecycle, persist the SDK's wallet state to IndexedDB so each restart resumes from the last checkpoint. The SDK provides serialization/restore on all three wallet types:
 
 ```typescript
-// offscreen.ts — persistent keepalive port
-function connectKeepalive() {
-  const port = chrome.runtime.connect({ name: 'gsd-keepalive' });
-  port.onDisconnect.addListener(() => {
-    // SW died — reconnect to force restart
-    setTimeout(connectKeepalive, 500);
-  });
-}
-connectKeepalive();
+// Serialize — call periodically during sync (e.g. every 30s)
+const [shielded, unshielded, dust] = await Promise.all([
+  facade.shielded.serializeState(),   // Returns string
+  facade.unshielded.serializeState(), // Returns string
+  facade.dust.serializeState(),       // Returns string
+]);
+const txHistory = txHistoryStorage.serialize(); // Also string
+
+// Persist to IndexedDB (keyed by environment + account)
+await db.put('sdkState', { shieldedState, unshieldedState, dustState, txHistory, savedAt, sdkVersion });
 ```
 
 ```typescript
-// messageRouter.ts — accept the keepalive port without broadcasting
-if (port.name === 'gsd-keepalive') {
-  return; // Just hold it open
+// Restore — on wallet initialization, check for checkpoint first
+const checkpoint = await db.get('sdkState', key);
+
+if (checkpoint) {
+  const txHistoryStorage = InMemoryTransactionHistoryStorage.fromSerialized(checkpoint.txHistory);
+  const facade = await WalletFacade.init({
+    configuration: { ...config, txHistoryStorage },
+    shielded: (cfg) => ShieldedWallet(cfg).restore(checkpoint.shieldedState),
+    unshielded: (cfg) => UnshieldedWallet(cfg).restore(checkpoint.unshieldedState),
+    dust: (cfg) => DustWallet(cfg).restore(checkpoint.dustState),
+    provingService: () => makeServerProvingService({ ... }),
+  });
+} else {
+  // Fresh init with startWithSeed/startWithPublicKey (existing code)
 }
 ```
 
-```typescript
-// walletManager.ts — create the offscreen document when wallet starts
-async function ensureOffscreenDocument(): Promise<void> {
-  const contexts = await chrome.runtime.getContexts({
-    contextTypes: ['OFFSCREEN_DOCUMENT' as chrome.runtime.ContextType],
-  });
-  if (contexts.length > 0) return;
-  await chrome.offscreen.createDocument({
-    url: 'src/offscreen/offscreen.html',
-    reasons: ['WORKERS' as chrome.offscreen.Reason],
-    justification: 'Keep service worker alive during wallet sync',
-  });
-}
-```
+**Checkpointing strategy:**
+- Save every 30 seconds during sync (throttled, fire-and-forget)
+- Save when `isSynced` transitions to `true`
+- Save before `facade.stop()` on wallet lock/shutdown
+- Never block the UI or state emission on checkpoint writes
+- Store the SDK package version — discard checkpoints after SDK upgrades
 
-Without this, mainnet sync (~87k shielded + ~87k dust events, ~6 minutes) will never complete — Chrome kills the SW every ~60 seconds and the SDK restarts from scratch each time.
+**Error handling:** Wrap restore in try/catch. If deserialization fails (corrupt data, schema change), clear the checkpoint and fall back to fresh sync. Checkpoint writes are best-effort — failures are logged but never crash the wallet.
 
-**Reference:** `gsd-wallet/src/offscreen/offscreen.ts`, `gsd-wallet/src/background/walletManager.ts:ensureOffscreenDocument`
+**Scoping:** Key checkpoints by `${environment}:${accountIndex}` so each wallet/network combination has independent state.
+
+**Tested on mainnet:** With ~87k shielded + ~87k dust events, the wallet completes full sync across multiple SW restarts (Chrome kills the SW every ~60s), each time resuming from the last 30-second checkpoint. Without persistent storage, this sync never completes.
+
+**Reference:** `gsd-wallet/src/background/sdkCheckpoint.ts`, `gsd-wallet/src/background/walletManager.ts:initializeWalletCore`, `gsd-wallet/src/shared/storage.ts`
 
 #### Popup height limit
 
@@ -746,8 +763,8 @@ On mainnet with ~87k shielded and ~87k dust events, first sync takes several min
 | Address shows as empty string | `MidnightBech32m.encode()` threw (address not yet synced) | Wrap in try-catch, show placeholder |
 | UTXO hash "Not found in indexer" | `intentHash` is not a transaction hash | Don't use intent hash as indexer lookup key |
 | Popup scrolls past bottom | Chrome enforces viewport height limit (~600px) | Cap popup height; offer "Open in Full Tab" |
-| Service worker dies mid-sync | Chrome kills idle SWs after ~30s; WebSockets don't count as activity | Use offscreen document with persistent port (not alarms alone) |
-| Sync restarts from 0 on every SW restart | `InMemoryTransactionHistoryStorage` loses all state | Offscreen keepalive prevents kills; persistent SDK storage adapter is the long-term fix |
+| Service worker dies mid-sync | Chrome kills idle SWs after ~30s; WebSockets don't count as activity | Persist SDK state to IndexedDB; restore from checkpoint on restart (see section 4) |
+| Sync restarts from 0 on every SW restart | `InMemoryTransactionHistoryStorage` and wallet state are in-memory only | Implement persistent SDK storage with `serializeState()`/`restore()` and `InMemoryTransactionHistoryStorage.serialize()`/`fromSerialized()` |
 | Popup shows stale data after close/reopen | Port message delivery unreliable in MV3 | Use `chrome.storage.onChanged` for live updates instead of port broadcasts |
 | Sync percentage inflated (61% shown, actual 43%) | Averaging per-wallet percentages equally | Use `totalApplied / totalHighest` across all wallets |
 | API call hangs after SW restart | `autoUnlock` reinitializes facade while API handler uses old ref | Gate API handlers with `waitForReady()` before using facade |
@@ -781,7 +798,7 @@ What the existing Midnight documentation covers vs what you actually need:
 | **Token type ID model** | Design.md (briefly) | utxo.mdx (conceptual) | **Partial** — theory but no practical guidance |
 | **React Native limitations** | — | — | **Gap** — no explicit statement of non-support |
 | **Chrome popup constraints** | — | — | **Gap** — 600px limit not documented |
-| **Keepalive patterns** | — | — | **Gap** — SW lifecycle not addressed |
+| **SW lifecycle & persistent storage** | — | — | **Addressed here** — checkpoint pattern with `serializeState()`/`restore()` |
 
 ---
 
@@ -792,7 +809,9 @@ The GSD Wallet provides working implementations of every pattern in this guide:
 | Pattern | File | Key function/section |
 |---------|------|---------------------|
 | Service worker polyfills | `src/background/index.ts` | Lines 1-38 |
-| Facade initialization (two-phase) | `src/background/walletManager.ts` | `initializeWalletCore()` — Phase 1: subscribe + emit initial state; Phase 2: `facade.start()` in background |
+| Facade initialization (two-phase, with checkpoint restore) | `src/background/walletManager.ts` | `initializeWalletCore()` — loads checkpoint, restores or fresh init, Phase 2: `facade.start()` in background |
+| Persistent SDK storage (checkpoint) | `src/background/sdkCheckpoint.ts` | `saveCheckpoint()`, `loadCheckpoint()`, `clearCheckpoint()` — IndexedDB-backed state persistence |
+| IndexedDB schema (v2, with sdkState store) | `src/shared/storage.ts` | `getSdkState()`, `saveSdkState()`, `deleteSdkState()`, `deleteAllSdkState()` |
 | SW race condition guard | `src/background/walletManager.ts` | `waitForReady()` |
 | State serialization | `src/background/walletManager.ts` | `serializeState()` |
 | Per-wallet sync progress | `src/popup/pages/Dashboard.tsx` | `SyncDetailRow` — always-visible rows showing applied/total per wallet |

--- a/src/background/messageRouter.ts
+++ b/src/background/messageRouter.ts
@@ -3,7 +3,11 @@ import type { SerializedWalletState } from '@shared/types';
 import { executeTransfer } from '@core/transfer';
 import { executeDustRegistration } from '@core/dustRegistration';
 import { executeDustDeregistration } from '@core/dustDeregistration';
-import { addTxHistoryEntry, getTxHistory } from '@shared/storage';
+import {
+  addTxHistoryEntry,
+  getTxHistory,
+  deleteAllSdkState,
+} from '@shared/storage';
 import { handleApiCall } from './connectedApiHandler';
 import * as stateManager from './stateManager';
 import * as walletManager from './walletManager';
@@ -308,6 +312,7 @@ async function handlePopupMessage(
       case 'CLEAR_ALL': {
         await walletManager.stopWallet();
         await stateManager.clearAll();
+        await deleteAllSdkState();
         break;
       }
 

--- a/src/background/sdkCheckpoint.ts
+++ b/src/background/sdkCheckpoint.ts
@@ -1,0 +1,90 @@
+import type { WalletFacade } from '@midnight-ntwrk/wallet-sdk-facade';
+import type { InMemoryTransactionHistoryStorage } from '@midnight-ntwrk/wallet-sdk-unshielded-wallet';
+import type { Environment, PersistedSdkState } from '@shared/types';
+import {
+  getSdkState,
+  saveSdkState,
+  deleteSdkState,
+  deleteAllSdkState,
+} from '@shared/storage';
+import { emit } from './diagnosticLogger';
+
+declare const __SDK_FACADE_VERSION__: string;
+
+export async function saveCheckpoint(
+  facade: WalletFacade,
+  txHistoryStorage: InMemoryTransactionHistoryStorage,
+  environment: Environment,
+  accountIndex: number,
+): Promise<void> {
+  const [shieldedState, unshieldedState, dustState] =
+    await Promise.all([
+      facade.shielded.serializeState(),
+      facade.unshielded.serializeState(),
+      facade.dust.serializeState(),
+    ]);
+
+  const state: PersistedSdkState = {
+    key: `${environment}:${accountIndex}`,
+    environment,
+    accountIndex,
+    shieldedState,
+    unshieldedState,
+    dustState,
+    txHistoryState: txHistoryStorage.serialize(),
+    savedAt: Date.now(),
+    sdkVersion: __SDK_FACADE_VERSION__,
+  };
+
+  await saveSdkState(state);
+  emit(
+    'debug',
+    'storage',
+    'Checkpoint saved',
+    { environment, accountIndex },
+  );
+}
+
+export async function loadCheckpoint(
+  environment: Environment,
+  accountIndex: number,
+): Promise<PersistedSdkState | null> {
+  const state = await getSdkState(environment, accountIndex);
+  if (!state) {
+    return null;
+  }
+
+  if (state.sdkVersion !== __SDK_FACADE_VERSION__) {
+    emit(
+      'info',
+      'storage',
+      'Checkpoint SDK version mismatch, discarding',
+      {
+        stored: state.sdkVersion,
+        current: __SDK_FACADE_VERSION__,
+      },
+    );
+    await deleteSdkState(environment, accountIndex);
+    return null;
+  }
+
+  return state;
+}
+
+export async function clearCheckpoint(
+  environment: Environment,
+  accountIndex: number,
+): Promise<void> {
+  await deleteSdkState(environment, accountIndex);
+  emit(
+    'debug',
+    'storage',
+    'Checkpoint cleared',
+    { environment, accountIndex },
+  );
+}
+
+export async function clearAllCheckpoints(): Promise<void> {
+  await deleteAllSdkState();
+  emit('debug', 'storage', 'All checkpoints cleared');
+}

--- a/src/background/walletManager.ts
+++ b/src/background/walletManager.ts
@@ -21,20 +21,29 @@ import type {
 import { NIGHT_TOKEN_ID } from '@shared/constants';
 import { getEnvironmentConfig } from '@shared/environments';
 import { emit } from './diagnosticLogger';
+import {
+  saveCheckpoint,
+  loadCheckpoint,
+  clearCheckpoint,
+} from './sdkCheckpoint';
 
 async function ensureOffscreenDocument(): Promise<void> {
   const contexts = await chrome.runtime.getContexts({
     contextTypes: ['OFFSCREEN_DOCUMENT' as chrome.runtime.ContextType],
   });
-  if (contexts.length > 0) return;
+  if (contexts.length > 0) {
+    emit('debug', 'sw', 'Offscreen document already exists');
+    return;
+  }
   try {
     await chrome.offscreen.createDocument({
       url: 'src/offscreen/offscreen.html',
       reasons: ['WORKERS' as chrome.offscreen.Reason],
       justification: 'Keep service worker alive during wallet sync via periodic ping',
     });
-  } catch {
-    // Already exists or not supported
+    emit('info', 'sw', 'Offscreen keepalive document created');
+  } catch (e) {
+    emit('error', 'sw', 'Failed to create offscreen document', { error: String(e) });
   }
 }
 
@@ -48,6 +57,7 @@ interface ActiveWallet {
   networkId: NetworkId.NetworkId;
   secretKeys: WalletSecretKeys;
   unshieldedKeystore: UnshieldedKeystore;
+  txHistoryStorage: InMemoryTransactionHistoryStorage;
   environment: Environment;
   accountIndex: number;
   walletName: string;
@@ -134,7 +144,7 @@ function serializeState(
     : false;
   const shieldedPercent = Number(sp.highestRelevantWalletIndex) === 0
     ? (sp.isConnected ? 100 : 0)
-    : (Number(sp.appliedIndex) / Number(sp.highestRelevantWalletIndex)) * 100;
+    : Math.min(100, (Number(sp.appliedIndex) / Number(sp.highestRelevantWalletIndex)) * 100);
 
   const up = facadeState.unshielded.progress;
   const unshieldedSynced = up.isConnected
@@ -142,7 +152,7 @@ function serializeState(
     : false;
   const unshieldedPercent = Number(up.highestTransactionId) === 0
     ? (up.isConnected ? 100 : 0)
-    : (Number(up.appliedId) / Number(up.highestTransactionId)) * 100;
+    : Math.min(100, (Number(up.appliedId) / Number(up.highestTransactionId)) * 100);
 
   const dp = facadeState.dust.progress;
   const dustSynced = dp.isConnected
@@ -152,7 +162,7 @@ function serializeState(
     : false;
   const dustPercent = Number(dp.highestRelevantWalletIndex) === 0
     ? (dp.isConnected ? 100 : 0)
-    : (Number(dp.appliedIndex) / Number(dp.highestRelevantWalletIndex)) * 100;
+    : Math.min(100, (Number(dp.appliedIndex) / Number(dp.highestRelevantWalletIndex)) * 100);
 
   const allConnected = sp.isConnected && up.isConnected && dp.isConnected;
   const totalApplied =
@@ -160,7 +170,7 @@ function serializeState(
   const totalHighest =
     Number(sp.highestRelevantWalletIndex) + Number(up.highestTransactionId) + Number(dp.highestRelevantWalletIndex);
   const overallSyncPercent = totalHighest > 0
-    ? Math.floor((totalApplied / totalHighest) * 100)
+    ? Math.min(100, Math.floor((totalApplied / totalHighest) * 100))
     : (allConnected ? 100 : 0);
   const reallySynced = facadeState.isSynced || (allConnected && shieldedSynced && unshieldedSynced && dustSynced);
 
@@ -316,6 +326,13 @@ async function initializeWalletCore(
     effectiveConfig.networkId,
   );
 
+  const checkpoint = await loadCheckpoint(environment, accountIndex);
+  const txHistoryStorage = checkpoint
+    ? InMemoryTransactionHistoryStorage.fromSerialized(
+        checkpoint.txHistoryState,
+      )
+    : new InMemoryTransactionHistoryStorage();
+
   const config = {
     networkId: effectiveConfig.networkId,
     indexerClientConnection: {
@@ -325,28 +342,97 @@ async function initializeWalletCore(
     provingServerUrl: new URL(effectiveConfig.provingServerUrl),
     relayURL: new URL(effectiveConfig.nodeWsUrl),
     costParameters: { feeBlocksMargin: 5 },
-    txHistoryStorage: new InMemoryTransactionHistoryStorage(),
+    txHistoryStorage,
   };
 
-  emit('info', 'wallet', 'Creating WalletFacade', { networkId: effectiveConfig.networkId, indexer: effectiveConfig.indexerHttpUrl, node: effectiveConfig.nodeWsUrl, prover: effectiveConfig.provingServerUrl });
-  const facadeT0 = Date.now();
-  const facade = await WalletFacade.init({
-    configuration: config,
-    shielded: (cfg) =>
-      ShieldedWallet(cfg).startWithSeed(
-        derivationResult.keys[Roles.Zswap],
-      ),
-    unshielded: (cfg) =>
-      UnshieldedWallet(cfg).startWithPublicKey(
-        PublicKey.fromKeyStore(unshieldedKeystore),
-      ),
-    dust: (cfg) =>
-      DustWallet(cfg).startWithSeed(
-        derivationResult.keys[Roles.Dust],
-        ledger.LedgerParameters.initialParameters().dust,
-      ),
-    provingService: () => makeServerProvingService({ provingServerUrl: new URL(effectiveConfig.provingServerUrl) }),
+  emit('info', 'wallet', 'Creating WalletFacade', {
+    networkId: effectiveConfig.networkId,
+    indexer: effectiveConfig.indexerHttpUrl,
+    node: effectiveConfig.nodeWsUrl,
+    prover: effectiveConfig.provingServerUrl,
+    restoringFromCheckpoint: checkpoint !== null,
   });
+  const facadeT0 = Date.now();
+  let facade: WalletFacade;
+
+  if (checkpoint) {
+    try {
+      emit('info', 'wallet', 'Restoring from checkpoint', {
+        savedAt: new Date(checkpoint.savedAt).toISOString(),
+        environment,
+      });
+      facade = await WalletFacade.init({
+        configuration: config,
+        shielded: (cfg) =>
+          ShieldedWallet(cfg).restore(checkpoint.shieldedState),
+        unshielded: (cfg) =>
+          UnshieldedWallet(cfg).restore(
+            checkpoint.unshieldedState,
+          ),
+        dust: (cfg) =>
+          DustWallet(cfg).restore(checkpoint.dustState),
+        provingService: () =>
+          makeServerProvingService({
+            provingServerUrl: new URL(
+              effectiveConfig.provingServerUrl,
+            ),
+          }),
+      });
+    } catch (restoreErr) {
+      emit(
+        'warn',
+        'wallet',
+        'Checkpoint restore failed, falling back to fresh sync',
+        { error: String(restoreErr) },
+      );
+      await clearCheckpoint(environment, accountIndex);
+      facade = await WalletFacade.init({
+        configuration: config,
+        shielded: (cfg) =>
+          ShieldedWallet(cfg).startWithSeed(
+            derivationResult.keys[Roles.Zswap],
+          ),
+        unshielded: (cfg) =>
+          UnshieldedWallet(cfg).startWithPublicKey(
+            PublicKey.fromKeyStore(unshieldedKeystore),
+          ),
+        dust: (cfg) =>
+          DustWallet(cfg).startWithSeed(
+            derivationResult.keys[Roles.Dust],
+            ledger.LedgerParameters.initialParameters().dust,
+          ),
+        provingService: () =>
+          makeServerProvingService({
+            provingServerUrl: new URL(
+              effectiveConfig.provingServerUrl,
+            ),
+          }),
+      });
+    }
+  } else {
+    facade = await WalletFacade.init({
+      configuration: config,
+      shielded: (cfg) =>
+        ShieldedWallet(cfg).startWithSeed(
+          derivationResult.keys[Roles.Zswap],
+        ),
+      unshielded: (cfg) =>
+        UnshieldedWallet(cfg).startWithPublicKey(
+          PublicKey.fromKeyStore(unshieldedKeystore),
+        ),
+      dust: (cfg) =>
+        DustWallet(cfg).startWithSeed(
+          derivationResult.keys[Roles.Dust],
+          ledger.LedgerParameters.initialParameters().dust,
+        ),
+      provingService: () =>
+        makeServerProvingService({
+          provingServerUrl: new URL(
+            effectiveConfig.provingServerUrl,
+          ),
+        }),
+    });
+  }
   emit('info', 'wallet', 'WalletFacade.init complete', undefined, Date.now() - facadeT0);
 
   // --- Phase 1: Subscribe + set activeWallet (fast, unblocks UI) ---
@@ -357,6 +443,9 @@ async function initializeWalletCore(
   let lastAppliedTotal = 0;
   let lastAdvanceTime = Date.now();
   let stallWarned = false;
+  let lastCheckpointTime = 0;
+  let wasSynced = false;
+  const CHECKPOINT_INTERVAL_MS = 30_000;
   const prevConnections = { shielded: false, unshielded: false, dust: false };
 
   const sub = facade.state().subscribe((facadeState) => {
@@ -444,6 +533,28 @@ async function initializeWalletCore(
       serialized.syncPhase = 'stalled';
     }
 
+    // Periodic checkpoint to IndexedDB for SW restart resilience
+    const cpNow = Date.now();
+    const syncedTransition =
+      facadeState.isSynced && !wasSynced;
+    if (
+      cpNow - lastCheckpointTime >= CHECKPOINT_INTERVAL_MS ||
+      syncedTransition
+    ) {
+      lastCheckpointTime = cpNow;
+      wasSynced = facadeState.isSynced;
+      saveCheckpoint(
+        facade,
+        txHistoryStorage,
+        environment,
+        accountIndex,
+      ).catch((err) => {
+        emit('warn', 'storage', 'Checkpoint failed', {
+          error: String(err),
+        });
+      });
+    }
+
     chrome.storage.session.set({ gsdLastState: serialized });
     for (const listener of stateListeners) {
       listener(serialized);
@@ -481,6 +592,7 @@ async function initializeWalletCore(
     networkId: effectiveConfig.networkId,
     secretKeys: { shieldedSecretKeys, dustSecretKey },
     unshieldedKeystore,
+    txHistoryStorage,
     environment,
     accountIndex,
     walletName,
@@ -535,6 +647,19 @@ export async function stopWallet(): Promise<void> {
     activeWallet.subscription.unsubscribe();
     if (activeWallet.stallCheckInterval) {
       clearInterval(activeWallet.stallCheckInterval);
+    }
+    // Save final checkpoint before stopping
+    try {
+      await saveCheckpoint(
+        activeWallet.facade,
+        activeWallet.txHistoryStorage,
+        activeWallet.environment,
+        activeWallet.accountIndex,
+      );
+    } catch (e) {
+      emit('warn', 'storage', 'Final checkpoint save failed', {
+        error: String(e),
+      });
     }
     // Clear cached state so next init doesn't show stale balances
     chrome.storage.session.remove('gsdLastState');

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -4,10 +4,12 @@ import type {
   PermissionRecord,
   TxHistoryEntry,
   WalletStore,
+  PersistedSdkState,
+  Environment,
 } from './types';
 
 const DB_NAME = 'gsd-wallet';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 type GsdDB = IDBPDatabase;
 
@@ -16,22 +18,19 @@ let dbPromise: Promise<GsdDB> | undefined;
 function getDb(): Promise<GsdDB> {
   if (!dbPromise) {
     dbPromise = openDB(DB_NAME, DB_VERSION, {
-      upgrade(db) {
-        if (!db.objectStoreNames.contains('vault')) {
+      upgrade(db, oldVersion) {
+        if (oldVersion < 1) {
           db.createObjectStore('vault');
-        }
-        if (!db.objectStoreNames.contains('permissions')) {
           db.createObjectStore('permissions', { keyPath: 'origin' });
-        }
-        if (!db.objectStoreNames.contains('txHistory')) {
-          const store = db.createObjectStore('txHistory', {
+          const txStore = db.createObjectStore('txHistory', {
             keyPath: 'txHash',
           });
-          store.createIndex('byAccount', 'accountIndex');
-          store.createIndex('byTimestamp', 'timestamp');
-        }
-        if (!db.objectStoreNames.contains('settings')) {
+          txStore.createIndex('byAccount', 'accountIndex');
+          txStore.createIndex('byTimestamp', 'timestamp');
           db.createObjectStore('settings');
+        }
+        if (oldVersion < 2) {
+          db.createObjectStore('sdkState', { keyPath: 'key' });
         }
       },
     });
@@ -141,4 +140,42 @@ export async function saveSetting<T>(
 ): Promise<void> {
   const db = await getDb();
   await db.put('settings', value, key);
+}
+
+// --- SDK State (checkpoint persistence) ---
+
+function sdkStateKey(
+  environment: Environment,
+  accountIndex: number,
+): string {
+  return `${environment}:${accountIndex}`;
+}
+
+export async function getSdkState(
+  environment: Environment,
+  accountIndex: number,
+): Promise<PersistedSdkState | undefined> {
+  const db = await getDb();
+  return db.get('sdkState', sdkStateKey(environment, accountIndex)) as
+    Promise<PersistedSdkState | undefined>;
+}
+
+export async function saveSdkState(
+  state: PersistedSdkState,
+): Promise<void> {
+  const db = await getDb();
+  await db.put('sdkState', state);
+}
+
+export async function deleteSdkState(
+  environment: Environment,
+  accountIndex: number,
+): Promise<void> {
+  const db = await getDb();
+  await db.delete('sdkState', sdkStateKey(environment, accountIndex));
+}
+
+export async function deleteAllSdkState(): Promise<void> {
+  const db = await getDb();
+  await db.clear('sdkState');
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -108,6 +108,18 @@ export interface SerializedWalletState {
   activeWalletName: string;
 }
 
+export interface PersistedSdkState {
+  key: string;
+  environment: Environment;
+  accountIndex: number;
+  shieldedState: string;
+  unshieldedState: string;
+  dustState: string;
+  txHistoryState: string;
+  savedAt: number;
+  sdkVersion: string;
+}
+
 export interface PermissionRecord {
   origin: string;
   networkId: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,15 @@ import { crx } from '@crxjs/vite-plugin';
 import wasm from 'vite-plugin-wasm';
 import topLevelAwait from 'vite-plugin-top-level-await';
 import { resolve } from 'path';
+import { readFileSync } from 'fs';
 import manifest from './manifest.json';
+
+const facadePkg = JSON.parse(
+  readFileSync(
+    resolve(__dirname, 'node_modules/@midnight-ntwrk/wallet-sdk-facade/package.json'),
+    'utf-8',
+  ),
+) as { version: string };
 
 export default defineConfig({
   plugins: [wasm(), topLevelAwait(), react(), crx({ manifest })],
@@ -20,6 +28,7 @@ export default defineConfig({
   },
   define: {
     'global': 'globalThis',
+    '__SDK_FACADE_VERSION__': JSON.stringify(facadePkg.version),
   },
   build: {
     target: 'es2022',


### PR DESCRIPTION
## Summary

- Persist all three sub-wallet states + transaction history to IndexedDB every 30s during sync
- Restore from checkpoint on service worker restart instead of syncing from scratch
- Mainnet sync (174k events, ~6 minutes) now completes across multiple SW kills
- Update integration guide with persistent storage pattern — required for any Chrome MV3 Midnight wallet

## Test plan

- [x] Fresh sync: checkpoint appears in IndexedDB after 30s
- [x] SW restart: sync resumes from checkpoint offset, not 0
- [x] Multiple restarts: full mainnet sync completes across 3+ SW lifecycles
- [x] Sync percentage clamped to 0-100 after restore (no overflow)
- [x] TypeScript typecheck passes
- [x] Vite build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)