### PR TITLE
Enable Dependabot with grouped weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      midnight-sdk:
+        patterns:
+          - "@midnight-ntwrk/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "vite-plugin-*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "autoprefixer"
+          - "postcss"


### PR DESCRIPTION
## Summary

- Enable Dependabot for npm dependencies with weekly schedule
- Group related packages to reduce PR noise: midnight-sdk, react, vite, tailwind
- Limit to 10 open PRs

## Test plan

- [ ] Verify Dependabot picks up the config and creates PRs on next schedule