### PR TITLE
Wallet manager menu, SDK-aligned seed handling, UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ Chrome extension wallet for dApp developers building on the [Midnight](https://m
 ## Features
 
 - **Multi-environment** — Undeployed (localhost), DevNet, QANet, Preview, PreProd, Mainnet
+- **Wallet manager menu** — unified dropdown showing all wallets grouped by network, with create/switch/delete/copy-seed actions
 - **Quick-start on localnet** — one-click import of 4 prefunded genesis wallets (W0-W3)
 - **Wallet management** — generate 24-word mnemonic or import seed phrase / hex seed
-- **Multi-wallet** — multiple wallets per environment with quick-switch
+- **Multi-wallet** — multiple wallets per environment, each with isolated sync state
 - **Shielded & unshielded transfers** — send tokens with ZK proving via server prover
 - **Dust operations** — register/deregister UTXOs for dust generation
 - **DApp connector** — `window.midnight` injection implementing the Midnight DApp connector API

--- a/docs/WALLET-INTEGRATION-GUIDE.md
+++ b/docs/WALLET-INTEGRATION-GUIDE.md
@@ -795,7 +795,7 @@ On mainnet with ~87k shielded and ~87k dust events, first sync takes several min
 | Sync percentage inflated (61% shown, actual 43%) | Averaging per-wallet percentages equally | Use `totalApplied / totalHighest` across all wallets |
 | API call hangs after SW restart | `autoUnlock` reinitializes facade while API handler uses old ref | Gate API handlers with `waitForReady()` before using facade |
 | DApp connects before user accepts disclaimer | Popup gate doesn't block service worker DApp handler | Check disclaimer in both popup AND DApp request handler independently |
-| `balanceUnboundTransaction` hangs | Facade balance method blocks indefinitely for some contract txs | Under investigation — diagnostics panel helps trace the exact stall point |
+| `balanceUnboundTransaction` hangs for contract calls | Dust balancer deterministic `IntentSegmentIdCollision` + 38s synchronous event loop block kills SW | Upstream SDK bug — see section 13 for full diagnosis. No GSD wallet fix possible. |
 | `HDWallet.fromSeed` returns but wallet fails later | Didn't check `.type === 'seedOk'` | Always check tagged return types |
 | Facade created but never syncs | Forgot to call `facade.start()` after `init()` | `.init()` and `.start()` are separate steps |
 | DApps can't discover wallet | Missing `midnight#ready` event dispatch | Dispatch `CustomEvent('midnight#ready')` after injection |
@@ -825,10 +825,15 @@ What the existing Midnight documentation covers vs what you actually need:
 | **React Native limitations** | — | — | **Gap** — no explicit statement of non-support |
 | **Chrome popup constraints** | — | — | **Gap** — 600px limit not documented |
 | **SW lifecycle & persistent storage** | — | — | **Addressed here** — checkpoint pattern with `serializeState()`/`restore()` |
+| **Facade computation model vs Chrome SW** | — | — | **Gap** — SDK assumes unbounded event loop blocking is safe; Chrome kills unresponsive SWs at ~30s. See section 14 |
+| **Dust balancer segment ID collision** | — | — | **Gap** — deterministic `IntentSegmentIdCollision` for all contract call transactions via DApp connector. See section 14 |
+| **Offscreen document for facade** | WASM prover example uses `makeWasmProvingService()` | — | **Gap** — SDK docs show WASM prover factory but don't address that the entire facade must run outside the SW for Chrome extensions |
 
 ---
 
 ## 12. Reference Implementation
+
+> **Note:** The reference implementation currently runs the facade in the service worker. Section 13 describes the required migration to the offscreen document.
 
 The GSD Wallet provides working implementations of every pattern in this guide:
 
@@ -862,7 +867,138 @@ Repository: `https://github.com/adamreynolds-io/gsd-wallet`
 
 ---
 
-## 13. Audit Findings (GSD Wallet v0.1.0)
+## 13. Facade Must Run Outside the Service Worker
+
+> **Not covered in SDK reference.** The SDK design docs (`docs/sdk-reference/design.md`) describe the variant/capability/SubscriptionRef architecture but assume a Node.js or Electron runtime. The SDK examples (`docs/sdk-reference/examples/wasm-prover.ts`) show `makeWasmProvingService()` as the production prover factory but don't address where the facade should live in a Chrome extension. This section fills that gap.
+
+### The problem
+
+The wallet SDK's `WalletFacade` runs long computations synchronously on the Effect runtime without yielding to the event loop. This is safe in Node.js and Electron. In a Chrome extension service worker, it is fatal.
+
+Chrome terminates any service worker whose event loop is blocked for approximately 30 seconds. The SDK's dust balancer (`transactingCapability.balanceTransactions()`) runs ~38 seconds of synchronous computation for contract call transactions. Chrome kills the service worker before the operation completes or errors. The DApp receives no response — a silent hang.
+
+This was verified by instrumenting the SDK's three balancers (shielded, unshielded, dust) with trace events. The trace shows all three semaphores are acquired instantly, the `blockData()` indexer fetch returns immediately, and the stall is entirely inside the dust balancer's synchronous computation phase. See [gsd-wallet#10](https://github.com/adamreynolds-io/gsd-wallet/issues/10) for the full evidence chain.
+
+Additionally, the dust balancer has a deterministic `IntentSegmentIdCollision` bug: it creates a fee intent on the same segment ID as the contract call intent in the input transaction. This collision occurs for every contract call transaction (not deploys, which use the fixed guaranteed segment). The collision is only detected after ~38 seconds of proving work, making the failure both slow and guaranteed.
+
+### Why `setTimeout` and `Promise.race` don't help
+
+A natural mitigation is to wrap the facade call in `Promise.race` with a `setTimeout` timeout:
+
+```typescript
+// THIS DOES NOT WORK
+const recipe = await Promise.race([
+  facade.balanceUnboundTransaction(tx, keys, { ttl }),
+  new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout')), 20_000)),
+]);
+```
+
+This fails because `setTimeout` callbacks are dispatched on the same event loop that the facade computation is blocking. While the dust balancer runs synchronously for 38 seconds, no `setTimeout` callback can fire. The timeout and the computation share a single thread — neither can interrupt the other.
+
+### Required architecture: service worker as supervisor
+
+The facade must run in a separate execution context with its own event loop. In Chrome MV3, the only available option is an **offscreen document**.
+
+```
+DApp <-> content script <-> service worker (supervisor) <-> offscreen document (facade)
+                                 |                               |
+                            message routing                 WalletFacade
+                            timeout enforcement             balancing, proving
+                            state cache for UI              sync, state subscriptions
+                            keepalive                       own event loop
+```
+
+The service worker never calls the facade directly. It sends a message to the offscreen document, starts a timeout, and waits for a response. Because the service worker's event loop is free, `setTimeout` works normally.
+
+```typescript
+// Service worker — timeout works because event loop is free
+async function balanceViaOffscreen(txHex: string): Promise<string> {
+  const id = crypto.randomUUID();
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Balance timed out after 60s'));
+    }, 60_000);
+
+    const handler = (msg: OffscreenMessage) => {
+      if (msg.id !== id) return;
+      clearTimeout(timeout);
+      offscreenPort.onMessage.removeListener(handler);
+      if (msg.error) reject(new Error(msg.error));
+      else resolve(msg.result);
+    };
+
+    offscreenPort.onMessage.addListener(handler);
+    offscreenPort.postMessage({ id, type: 'balance', txHex });
+  });
+}
+```
+
+The offscreen document has no lifecycle limit from Chrome — it stays alive as long as the service worker keeps it open. If it crashes, Chrome notifies the service worker via the port disconnect event.
+
+### What moves to the offscreen document
+
+| Component | Currently | Should be |
+|-----------|-----------|-----------|
+| `WalletFacade.init()` + full facade instance | Service worker | Offscreen document |
+| Shielded/unshielded/dust wallets | Service worker | Offscreen document |
+| Proving service (`makeServerProvingService` or `makeWasmProvingService`) | Service worker | Offscreen document |
+| Sync service + state subscriptions | Service worker | Offscreen document |
+| `balanceUnboundTransaction`, `finalizeRecipe`, all transacting | Service worker | Offscreen document |
+| Message routing (DApp connector, popup) | Service worker | Service worker (stays) |
+| Timeout enforcement | Service worker | Service worker (stays) |
+| State cache for popup UI | Service worker | Service worker (receives snapshots from offscreen) |
+| Checkpoint triggers | Service worker | Service worker (sends save command to offscreen) |
+
+### Heartbeat protocol for proving
+
+When the SDK takes on WASM proving (via `makeWasmProvingService()`), operations can take minutes. The offscreen document should send periodic heartbeats so the service worker can distinguish "still working" from "stalled":
+
+```typescript
+// Offscreen document
+async function proveWithHeartbeat(id: string, recipe: BalancingRecipe) {
+  const heartbeat = setInterval(() => {
+    port.postMessage({ id, type: 'heartbeat', phase: 'proving' });
+  }, 5_000);
+  try {
+    const result = await facade.finalizeRecipe(recipe);
+    port.postMessage({ id, type: 'result', result: serialize(result) });
+  } finally {
+    clearInterval(heartbeat);
+  }
+}
+
+// Service worker
+const HEARTBEAT_TIMEOUT = 15_000;
+let lastHeartbeat = Date.now();
+const monitor = setInterval(() => {
+  if (Date.now() - lastHeartbeat > HEARTBEAT_TIMEOUT) {
+    clearInterval(monitor);
+    reject(new Error('Proving stalled — no heartbeat for 15s'));
+  }
+}, 5_000);
+```
+
+### The SDK's factory pattern supports this
+
+`WalletFacade.init()` accepts factory functions for each wallet and the proving service. The facade doesn't care which execution context instantiates it. The factories work identically in a service worker or an offscreen document — they only require `fetch`, `WebSocket`, and `IndexedDB`, all of which are available in offscreen documents.
+
+The state bridge is straightforward: the offscreen document subscribes to `facade.state()` and posts serialized snapshots to the service worker on each emission. This is the same serialization already implemented for `chrome.storage.session` writes in the current architecture — the serialization just crosses a `postMessage` boundary instead of happening in-process.
+
+### Upstream SDK issues (not addressable from wallet side)
+
+Two issues require upstream fixes in `@midnight-ntwrk/wallet-sdk-dust-wallet`:
+
+1. **Deterministic segment ID collision**: The dust balancer creates fee intents on the same segment ID as the input transaction's contract call intent. This causes `IntentSegmentIdCollision` for every contract call transaction via the DApp connector. Deploy transactions (segment ID 1) are not affected. The fix: the dust balancer must exclude input transaction segment IDs when creating its fee intent.
+
+2. **Synchronous event loop blocking**: The dust balancer's `transactingCapability.balanceTransactions()` runs ~38 seconds of computation (internal proving) without yielding to the event loop. Even after the collision is fixed, any operation that blocks for >30 seconds is incompatible with Chrome's service worker lifecycle. The fix: the Effect runtime should yield periodically (via `scheduler.yield()` or `setTimeout(0)` trampolining) during long computations.
+
+### Validation
+
+The diagnosis was verified with [adamreynolds-io/issue-734-validation](https://github.com/adamreynolds-io/issue-734-validation) (7 Node.js tests proving the bug is browser-specific) and SDK trace instrumentation in the Chrome extension (identifying the exact stall point inside `dust: balanceTransactions COMPUTING`). Full evidence at [gsd-wallet#10](https://github.com/adamreynolds-io/gsd-wallet/issues/10).
+
+---
+
+## 14. Audit Findings (GSD Wallet v0.1.0)
 
 Code audit performed 2026-03-28 against wallet-sdk v3.0.0 documentation.
 

--- a/src/background/messageRouter.ts
+++ b/src/background/messageRouter.ts
@@ -314,6 +314,51 @@ async function handlePopupMessage(
         break;
       }
 
+      case 'GET_ALL_WALLETS': {
+        const result = await stateManager.getAllWalletsGrouped();
+        send({ type: 'ALL_WALLETS', ...result });
+        break;
+      }
+
+      case 'DELETE_WALLET': {
+        try {
+          const info = await stateManager.getActiveWalletInfo();
+          const wasActive = info?.walletIndex === msg.index;
+          await stateManager.deleteWallet(msg.index);
+          if (wasActive) {
+            await walletManager.stopWallet();
+            const newInfo = await stateManager.getActiveWalletInfo();
+            if (newInfo) {
+              const store = await stateManager.getStore();
+              const entry = store.wallets[newInfo.walletIndex];
+              const seed = stateManager.getSeed() ?? (entry ? new Uint8Array(entry.seed) : null);
+              if (!seed) break;
+              await walletManager.initializeWallet(
+                seed, newInfo.environment, 0, newInfo.name,
+              );
+            }
+          }
+          send({ type: 'WALLET_DELETED', success: true });
+        } catch (err) {
+          send({
+            type: 'WALLET_DELETED',
+            success: false,
+            error: err instanceof Error ? err.message : 'Failed to delete',
+          });
+        }
+        break;
+      }
+
+      case 'GET_WALLET_SEED': {
+        const store = await stateManager.getStore();
+        const entry = store.wallets[msg.index];
+        if (entry) {
+          const hex = Array.from(entry.seed, (b) => b.toString(16).padStart(2, '0')).join('');
+          send({ type: 'WALLET_SEED', seedHex: hex });
+        }
+        break;
+      }
+
       case 'LOCK': {
         await walletManager.stopWallet();
         stateManager.lock();

--- a/src/background/sdkCheckpoint.ts
+++ b/src/background/sdkCheckpoint.ts
@@ -16,6 +16,7 @@ export async function saveCheckpoint(
   txHistoryStorage: InMemoryTransactionHistoryStorage,
   environment: Environment,
   accountIndex: number,
+  walletId: string,
 ): Promise<void> {
   const [shieldedState, unshieldedState, dustState] =
     await Promise.all([
@@ -25,7 +26,7 @@ export async function saveCheckpoint(
     ]);
 
   const state: PersistedSdkState = {
-    key: `${environment}:${accountIndex}`,
+    key: `${environment}:${accountIndex}:${walletId}`,
     environment,
     accountIndex,
     shieldedState,
@@ -48,8 +49,9 @@ export async function saveCheckpoint(
 export async function loadCheckpoint(
   environment: Environment,
   accountIndex: number,
+  walletId: string,
 ): Promise<PersistedSdkState | null> {
-  const state = await getSdkState(environment, accountIndex);
+  const state = await getSdkState(environment, accountIndex, walletId);
   if (!state) {
     return null;
   }
@@ -64,7 +66,7 @@ export async function loadCheckpoint(
         current: __SDK_FACADE_VERSION__,
       },
     );
-    await deleteSdkState(environment, accountIndex);
+    await deleteSdkState(environment, accountIndex, walletId);
     return null;
   }
 
@@ -74,8 +76,9 @@ export async function loadCheckpoint(
 export async function clearCheckpoint(
   environment: Environment,
   accountIndex: number,
+  walletId: string,
 ): Promise<void> {
-  await deleteSdkState(environment, accountIndex);
+  await deleteSdkState(environment, accountIndex, walletId);
   emit(
     'debug',
     'storage',

--- a/src/background/stateManager.ts
+++ b/src/background/stateManager.ts
@@ -107,6 +107,40 @@ export async function clearAll(): Promise<void> {
   await saveWalletStore({ wallets: [], activeEnvironment: 'undeployed', activeWalletIndex: 0 });
 }
 
+export async function deleteWallet(index: number): Promise<void> {
+  const store = await getStore();
+  if (!store.wallets[index]) throw new Error(`Wallet ${index} not found`);
+  store.wallets.splice(index, 1);
+  if (store.wallets.length === 0) {
+    store.activeWalletIndex = 0;
+    store.activeEnvironment = 'undeployed';
+  } else if (index <= store.activeWalletIndex) {
+    store.activeWalletIndex = Math.max(0, store.activeWalletIndex - 1);
+    const w = store.wallets[store.activeWalletIndex];
+    if (w) store.activeEnvironment = w.environment;
+  }
+  await saveWalletStore(store);
+}
+
+export async function getAllWalletsGrouped(): Promise<{
+  wallets: Record<Environment, Array<{ index: number; name: string }>>;
+  activeWalletIndex: number;
+  activeEnvironment: Environment;
+}> {
+  const store = await getStore();
+  const grouped: Record<string, Array<{ index: number; name: string }>> = {
+    mainnet: [], preprod: [], preview: [], qanet: [], dev: [], undeployed: [],
+  };
+  store.wallets.forEach((w, i) => {
+    grouped[w.environment]?.push({ index: i, name: w.name });
+  });
+  return {
+    wallets: grouped as Record<Environment, Array<{ index: number; name: string }>>,
+    activeWalletIndex: store.activeWalletIndex,
+    activeEnvironment: store.activeEnvironment,
+  };
+}
+
 export async function getActiveWalletInfo(): Promise<{ environment: Environment; walletIndex: number; name: string } | null> {
   const store = await getStore();
   const wallet = store.wallets[store.activeWalletIndex];

--- a/src/background/walletManager.ts
+++ b/src/background/walletManager.ts
@@ -61,6 +61,7 @@ interface ActiveWallet {
   environment: Environment;
   accountIndex: number;
   walletName: string;
+  walletId: string;
   subscription: { unsubscribe(): void };
   latestState: FacadeState | null;
   startPromise: Promise<void> | null;
@@ -295,9 +296,12 @@ async function initializeWalletCore(
     ? { ...envConfig, ...customUrls }
     : envConfig;
 
+  const walletId = Array.from(seed.slice(0, 8), (b) => b.toString(16).padStart(2, '0')).join('');
+
   emit('debug', 'wallet', 'Deriving HD keys');
-  const hdWallet = HDWallet.fromSeed(seed);
-  seed.fill(0);
+  const seedCopy = new Uint8Array(seed);
+  const hdWallet = HDWallet.fromSeed(seedCopy);
+  seedCopy.fill(0);
   if (hdWallet.type !== 'seedOk') {
     emit('error', 'wallet', 'HDWallet.fromSeed failed', { type: hdWallet.type });
     throw new Error('Failed to initialize HDWallet from seed');
@@ -330,7 +334,7 @@ async function initializeWalletCore(
     effectiveConfig.networkId,
   );
 
-  const checkpoint = await loadCheckpoint(environment, accountIndex);
+  const checkpoint = await loadCheckpoint(environment, accountIndex, walletId);
   const txHistoryStorage = checkpoint
     ? InMemoryTransactionHistoryStorage.fromSerialized(
         checkpoint.txHistoryState,
@@ -389,7 +393,7 @@ async function initializeWalletCore(
         'Checkpoint restore failed, falling back to fresh sync',
         { error: String(restoreErr) },
       );
-      await clearCheckpoint(environment, accountIndex);
+      await clearCheckpoint(environment, accountIndex, walletId);
       facade = await WalletFacade.init({
         configuration: config,
         shielded: (cfg) =>
@@ -553,6 +557,7 @@ async function initializeWalletCore(
         txHistoryStorage,
         environment,
         accountIndex,
+        walletId,
       ).catch((err) => {
         emit('warn', 'storage', 'Checkpoint failed', {
           error: String(err),
@@ -601,6 +606,7 @@ async function initializeWalletCore(
     environment,
     accountIndex,
     walletName,
+    walletId,
     subscription: sub,
     latestState: null,
     startPromise: null,
@@ -660,6 +666,7 @@ export async function stopWallet(): Promise<void> {
         activeWallet.txHistoryStorage,
         activeWallet.environment,
         activeWallet.accountIndex,
+        activeWallet.walletId,
       );
     } catch (e) {
       emit('warn', 'storage', 'Final checkpoint save failed', {

--- a/src/popup/components/Header.tsx
+++ b/src/popup/components/Header.tsx
@@ -1,86 +1,25 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePopupStore } from '@popup/store/popupStore';
-import { ENVIRONMENT_OPTIONS, getEnvironmentLabel } from '@shared/environments';
-import type { Environment, SerializedWalletState } from '@shared/types';
-
-const LOCALNET_WALLETS = [0, 1, 2, 3];
+import { getEnvironmentLabel } from '@shared/environments';
+import type { SerializedWalletState } from '@shared/types';
+import { WalletMenu } from './WalletMenu';
 
 export function Header() {
   const navigate = useNavigate();
   const status = usePopupStore((s) => s.status);
   const walletState = usePopupStore((s) => s.walletState);
   const environment = usePopupStore((s) => s.environment);
-  const [wallets, setWallets] = useState<Array<{ index: number; name: string }>>([]);
-  const activeWalletName = walletState?.activeWalletName ?? '';
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuContainerRef = useRef<HTMLDivElement>(null);
 
   const currentEnv = walletState?.environment ?? environment;
   const isActive = status !== 'uninitialized';
-  const isLocalnet = currentEnv === 'undeployed';
 
-  const refreshWallets = useCallback(() => {
-    if (!isActive) return;
-    const port = chrome.runtime.connect({ name: 'gsd-popup' });
-    port.postMessage({ type: 'GET_WALLETS', environment: currentEnv });
-    port.onMessage.addListener((msg) => {
-      if (msg.type === 'WALLETS_LIST') {
-        setWallets(msg.wallets);
-      }
-      port.disconnect();
-    });
-  }, [currentEnv, isActive]);
-
-  useEffect(() => {
-    refreshWallets();
-  }, [refreshWallets]);
-
-  function handleNetworkSwitch(env: Environment) {
-    if (env === currentEnv) return;
-    const port = chrome.runtime.connect({ name: 'gsd-env-switch' });
-    port.postMessage({ type: 'SWITCH_ENVIRONMENT', environment: env });
-    port.onMessage.addListener((msg) => {
-      if (msg.type === 'ERROR') {
-        port.disconnect();
-        navigate('/onboarding');
-      }
-    });
-  }
-
-  function handleLocalnetWallet(walletIndex: number) {
-    const existing = wallets.find((w) => w.name === `Wallet ${walletIndex}`);
-    if (existing && activeWalletName !== `Wallet ${walletIndex}`) {
-      // Already imported with correct seed, just switch
-      const port = chrome.runtime.connect({ name: 'gsd-popup' });
-      port.postMessage({ type: 'SWITCH_WALLET', index: existing.index });
-      port.disconnect();
-    } else if (!existing) {
-      // Genesis wallets use seeds 1-4 (seed 1 = master wallet with all minted NIGHT)
-      const hex = (walletIndex + 1).toString(16).padStart(64, '0');
-      const bytes: number[] = [];
-      for (let i = 0; i < 32; i++) {
-        bytes.push(parseInt(hex.slice(i * 2, i * 2 + 2), 16));
-      }
-      const port = chrome.runtime.connect({ name: 'gsd-popup' });
-      port.postMessage({
-        type: 'ADD_WALLET',
-        name: `Wallet ${walletIndex}`,
-        seed: bytes,
-        environment: 'undeployed' as Environment,
-      });
-      port.onMessage.addListener((msg) => {
-        if (msg.type === 'WALLET_ADDED') {
-          refreshWallets();
-        }
-        port.disconnect();
-      });
-    }
-  }
-
-  function handleWalletSwitch(index: number) {
-    const port = chrome.runtime.connect({ name: 'gsd-popup' });
-    port.postMessage({ type: 'SWITCH_WALLET', index });
-    port.disconnect();
-  }
+  const rawName = walletState?.activeWalletName ?? '';
+  const headerLabel = /^Wallet [0-3]$/.test(rawName) && currentEnv === 'undeployed'
+    ? `Genesis W${rawName.slice(-1)}`
+    : currentEnv ? getEnvironmentLabel(currentEnv) : 'No Wallet';
 
   return (
     <>
@@ -97,77 +36,31 @@ export function Header() {
         </div>
         {isActive && (
           <>
-            <select
-              className="text-xs bg-midnight-600 text-gray-300 border border-midnight-400 rounded px-1.5 py-0.5 cursor-pointer focus:outline-none focus:border-accent-purple"
-              value={currentEnv}
-              onChange={(e) => handleNetworkSwitch(e.target.value as Environment)}
-            >
-              {ENVIRONMENT_OPTIONS.map((opt) => (
-                <option key={opt.value} value={opt.value}>{opt.label}</option>
-              ))}
-            </select>
+            <div className="relative" ref={menuContainerRef}>
+              <button
+                onClick={() => setMenuOpen((prev) => !prev)}
+                aria-expanded={menuOpen}
+                aria-haspopup="true"
+                className="flex items-center gap-1.5 text-xs bg-midnight-600 text-gray-300 border border-midnight-400 rounded px-2 py-1 hover:bg-midnight-500 hover:border-midnight-300 transition-colors cursor-pointer"
+              >
+                <span className="font-medium text-white truncate max-w-[140px]">
+                  {headerLabel}
+                </span>
+                <ChevronDownIcon />
+              </button>
+              <WalletMenu
+                isOpen={menuOpen}
+                onClose={() => setMenuOpen(false)}
+                currentEnv={currentEnv}
+                containerRef={menuContainerRef}
+              />
+            </div>
             <SyncStatusBadge walletState={walletState} />
           </>
         )}
       </div>
 
       <div className="flex items-center gap-1.5">
-        {/* Localnet wallet picker */}
-        {isActive && isLocalnet && (
-          <div className="flex items-center gap-0.5">
-            <button
-              onClick={() => {
-                if (confirm('Clear all wallets?')) {
-                  const port = chrome.runtime.connect({ name: 'gsd-popup' });
-                  port.postMessage({ type: 'CLEAR_ALL' });
-                  port.disconnect();
-                  usePopupStore.getState().setHasVault(false);
-                  usePopupStore.getState().setStatus('uninitialized');
-                  usePopupStore.getState().setWalletState(null as never);
-                  navigate('/onboarding');
-                }
-              }}
-              className="text-[10px] px-1 py-0.5 rounded text-gray-500 hover:text-status-red hover:bg-midnight-600 transition-colors"
-              title="Clear all wallets"
-            >
-              &#x2715;
-            </button>
-            {LOCALNET_WALLETS.map((i) => {
-              const imported = wallets.some((w) => w.name === `Wallet ${i}`);
-              const isCurrentWallet = activeWalletName === `Wallet ${i}`;
-              return (
-                <button
-                  key={i}
-                  onClick={() => handleLocalnetWallet(i)}
-                  className={`text-[10px] px-1.5 py-0.5 rounded font-mono transition-colors ${
-                    isCurrentWallet
-                      ? 'bg-accent-purple text-white'
-                      : imported
-                        ? 'bg-midnight-600 text-gray-300 hover:bg-midnight-500'
-                        : 'bg-midnight-700 text-gray-500 hover:bg-midnight-600 hover:text-gray-300'
-                  }`}
-                  title={imported ? `Switch to Wallet ${i}` : `Import Wallet ${i}`}
-                >
-                  W{i}
-                </button>
-              );
-            })}
-          </div>
-        )}
-
-        {/* Non-localnet wallet switcher */}
-        {isActive && !isLocalnet && wallets.length > 1 && (
-          <select
-            className="text-xs bg-midnight-600 text-gray-300 border border-midnight-400 rounded px-1.5 py-0.5 cursor-pointer focus:outline-none focus:border-accent-purple"
-            value={wallets.find((w) => w.name === activeWalletName)?.index ?? 0}
-            onChange={(e) => handleWalletSwitch(Number(e.target.value))}
-          >
-            {wallets.map((w) => (
-              <option key={w.index} value={w.index}>{w.name}</option>
-            ))}
-          </select>
-        )}
-
         <a
           href="https://github.com/adamreynolds-io/gsd-wallet"
           target="_blank"
@@ -279,6 +172,14 @@ function SyncStatusBadge({ walletState }: { walletState: SerializedWalletState |
   }
 
   return <span className={`text-xs ${color}`}>{text}</span>;
+}
+
+function ChevronDownIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
 }
 
 function SettingsIcon() {

--- a/src/popup/components/WalletMenu.tsx
+++ b/src/popup/components/WalletMenu.tsx
@@ -1,0 +1,282 @@
+import { useState, useEffect, type RefObject } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { usePopupStore } from '@popup/store/popupStore';
+import { ENVIRONMENT_OPTIONS, getEnvironmentLabel } from '@shared/environments';
+import type { Environment } from '@shared/types';
+
+interface WalletMenuProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentEnv: Environment | '';
+  containerRef: RefObject<HTMLDivElement | null>;
+}
+
+type WalletEntry = { index: number; name: string };
+type GroupedWallets = Record<Environment, WalletEntry[]>;
+
+const GENESIS_SEEDS = [0, 1, 2, 3];
+
+function isGenesis(w: WalletEntry, env: string): boolean {
+  return env === 'undeployed' && /^Wallet [0-3]$/.test(w.name);
+}
+
+function displayName(
+  w: WalletEntry,
+  positionInEnv: number,
+  env: string,
+): string {
+  if (isGenesis(w, env)) return `Genesis W${w.name.slice(-1)}`;
+  return `${getEnvironmentLabel(env as Environment)} ${positionInEnv}`;
+}
+
+export function WalletMenu({
+  isOpen,
+  onClose,
+  currentEnv,
+  containerRef,
+}: WalletMenuProps) {
+  const navigate = useNavigate();
+  const [wallets, setWallets] = useState<GroupedWallets | null>(null);
+  const [activeIdx, setActiveIdx] = useState(-1);
+  const [copiedIdx, setCopiedIdx] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCopiedIdx(null);
+      return;
+    }
+    fetchWallets();
+  }, [isOpen]);
+
+  function fetchWallets() {
+    const port = chrome.runtime.connect({ name: 'gsd-popup' });
+    port.postMessage({ type: 'GET_ALL_WALLETS' });
+    port.onMessage.addListener((msg) => {
+      if (msg.type !== 'ALL_WALLETS') return;
+      setWallets(msg.wallets);
+      setActiveIdx(msg.activeWalletIndex);
+      port.disconnect();
+    });
+  }
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    function onClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onClick);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onClick);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  function switchWallet(index: number) {
+    const port = chrome.runtime.connect({ name: 'gsd-popup' });
+    port.postMessage({ type: 'SWITCH_WALLET', index });
+    port.disconnect();
+    onClose();
+  }
+
+  function deleteWallet(index: number) {
+    const port = chrome.runtime.connect({ name: 'gsd-popup' });
+    port.postMessage({ type: 'DELETE_WALLET', index });
+    port.onMessage.addListener((msg) => {
+      if (msg.type !== 'WALLET_DELETED') return;
+      if (msg.success) fetchWallets();
+      port.disconnect();
+    });
+  }
+
+  function copySeed(index: number) {
+    const port = chrome.runtime.connect({ name: 'gsd-popup' });
+    port.postMessage({ type: 'GET_WALLET_SEED', index });
+    port.onMessage.addListener((msg) => {
+      if (msg.type !== 'WALLET_SEED') return;
+      navigator.clipboard.writeText(msg.seedHex);
+      setCopiedIdx(index);
+      setTimeout(() => setCopiedIdx(null), 2000);
+      port.disconnect();
+    });
+  }
+
+  function addGenesisWallet(walletIndex: number) {
+    const hex = (walletIndex + 1).toString(16).padStart(64, '0');
+    const bytes: number[] = [];
+    for (let i = 0; i < 32; i++) {
+      bytes.push(parseInt(hex.slice(i * 2, i * 2 + 2), 16));
+    }
+    const port = chrome.runtime.connect({ name: 'gsd-popup' });
+    port.postMessage({
+      type: 'ADD_WALLET',
+      name: `Wallet ${walletIndex}`,
+      seed: bytes,
+      environment: 'undeployed' as Environment,
+    });
+    port.onMessage.addListener(() => {
+      port.disconnect();
+      onClose();
+    });
+  }
+
+  function clearAll() {
+    if (!confirm('Clear all wallets?')) return;
+    const port = chrome.runtime.connect({ name: 'gsd-popup' });
+    port.postMessage({ type: 'CLEAR_ALL' });
+    port.disconnect();
+    usePopupStore.getState().setHasVault(false);
+    usePopupStore.getState().setStatus('uninitialized');
+    usePopupStore.getState().setWalletState(null as never);
+    onClose();
+    navigate('/onboarding');
+  }
+
+  return (
+    <div
+      role="menu"
+      className="absolute top-full left-0 mt-1 w-72 z-50 bg-midnight-700 border border-midnight-500 rounded-lg shadow-xl max-h-[480px] overflow-y-auto"
+    >
+      {/* Actions */}
+      <div className="p-1.5 border-b border-midnight-500">
+        <button
+          role="menuitem"
+          className="w-full text-left text-xs px-2.5 py-1.5 rounded text-gray-200 hover:bg-midnight-600 transition-colors"
+          onClick={() => { onClose(); navigate('/onboarding'); }}
+        >
+          + New Wallet
+        </button>
+        <button
+          role="menuitem"
+          className="w-full text-left text-xs px-2.5 py-1.5 rounded text-gray-400 hover:bg-midnight-600 transition-colors"
+          onClick={() => {
+            chrome.tabs.create({ url: chrome.runtime.getURL('src/popup/index.html#/settings') });
+            onClose();
+          }}
+        >
+          Manage...
+        </button>
+      </div>
+
+      {/* Grouped wallet list */}
+      <div className="py-1">
+        {ENVIRONMENT_OPTIONS.map((opt) => {
+          const env = opt.value as Environment;
+          const envWallets = wallets?.[env] ?? [];
+          const isEmpty = envWallets.length === 0;
+          const isUndeployed = env === 'undeployed';
+
+          // Count non-genesis wallets for numbering
+          let nonGenesisIdx = 0;
+
+          return (
+            <div key={env}>
+              <div className={`px-2.5 py-1 text-[10px] uppercase tracking-wider font-medium ${isEmpty && !isUndeployed ? 'text-gray-600' : 'text-gray-400'}`}>
+                {opt.label}
+                {envWallets.length > 0 && (
+                  <span className="ml-1 text-gray-600">({envWallets.length})</span>
+                )}
+              </div>
+
+              {envWallets.map((w) => {
+                const genesis = isGenesis(w, env);
+                const posIdx = genesis ? 0 : nonGenesisIdx++;
+                const label = displayName(w, posIdx, env);
+                const isActive = w.index === activeIdx && env === currentEnv;
+
+                return (
+                  <div
+                    key={w.index}
+                    className={`group flex items-center text-xs transition-colors ${
+                      isActive
+                        ? 'bg-accent-purple/15 text-white border-l-2 border-accent-purple'
+                        : 'text-gray-300 hover:bg-midnight-600 border-l-2 border-transparent'
+                    }`}
+                  >
+                    <button
+                      role="menuitem"
+                      onClick={() => switchWallet(w.index)}
+                      className="flex-1 text-left px-2.5 py-1 truncate"
+                    >
+                      {label}
+                    </button>
+                    {isActive && (
+                      <span className="text-accent-purple shrink-0 text-[10px]">&#10003;</span>
+                    )}
+                    <button
+                      onClick={(e) => { e.stopPropagation(); copySeed(w.index); }}
+                      className={`shrink-0 px-1 py-1 text-[10px] transition-opacity ${
+                        copiedIdx === w.index
+                          ? 'text-green-400 opacity-100'
+                          : 'text-gray-600 hover:text-gray-300 opacity-0 group-hover:opacity-100'
+                      }`}
+                      title="Copy seed hex"
+                    >
+                      {copiedIdx === w.index ? '\u2713' : '\u2398'}
+                    </button>
+                    {!genesis && (
+                      <button
+                        onClick={(e) => { e.stopPropagation(); deleteWallet(w.index); }}
+                        className="shrink-0 px-1 py-1 text-gray-600 hover:text-status-red opacity-0 group-hover:opacity-100 transition-opacity"
+                        title="Delete wallet"
+                      >
+                        &#x2715;
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+
+              {/* Genesis wallet quick-add buttons */}
+              {isUndeployed && (
+                <div className="flex gap-1 px-2.5 py-1">
+                  {GENESIS_SEEDS.map((i) => {
+                    const exists = envWallets.some((w) => w.name === `Wallet ${i}`);
+                    const isActive = exists && envWallets.find((w) => w.name === `Wallet ${i}`)?.index === activeIdx;
+                    return (
+                      <button
+                        key={i}
+                        onClick={() => exists
+                          ? switchWallet(envWallets.find((w) => w.name === `Wallet ${i}`)!.index)
+                          : addGenesisWallet(i)
+                        }
+                        className={`text-[10px] px-1.5 py-0.5 rounded font-mono transition-colors ${
+                          isActive
+                            ? 'bg-accent-purple text-white'
+                            : exists
+                              ? 'bg-midnight-600 text-gray-300 hover:bg-midnight-500'
+                              : 'bg-midnight-800 text-gray-500 hover:bg-midnight-600 hover:text-gray-300'
+                        }`}
+                        title={exists ? `Switch to Genesis W${i}` : `Import Genesis W${i}`}
+                      >
+                        W{i}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Clear all */}
+      <div className="border-t border-midnight-500 p-1.5">
+        <button
+          role="menuitem"
+          className="w-full text-left text-xs px-2.5 py-1.5 rounded text-status-red/70 hover:bg-midnight-600 hover:text-status-red transition-colors"
+          onClick={clearAll}
+        >
+          Clear All Wallets
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/popup/pages/Onboarding.tsx
+++ b/src/popup/pages/Onboarding.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { usePopupStore } from '@popup/store/popupStore';
-import { ENVIRONMENT_OPTIONS } from '@shared/environments';
+import { ENVIRONMENT_OPTIONS, getEnvironmentLabel } from '@shared/environments';
 import type { Environment, SeedType } from '@shared/types';
 
 type Step =
@@ -92,7 +92,8 @@ export function Onboarding() {
         }
       }
 
-      const walletName = nameOverride ?? (seedWords.length > 0 ? 'Generated' : 'Imported');
+      const envLabel = environment ? getEnvironmentLabel(environment) : 'Wallet';
+      const walletName = nameOverride ?? envLabel;
       const port = chrome.runtime.connect({ name: 'gsd-popup' });
       port.postMessage({
         type: 'ADD_WALLET',
@@ -102,18 +103,21 @@ export function Onboarding() {
       });
 
       port.onMessage.addListener((msg) => {
-        setCreating(false);
-        if (msg.type === 'WALLET_ADDED' && msg.success) {
-          setSeedWords([]);
-          setSeedInput('');
-          usePopupStore.getState().setHasVault(true);
-          setStatus('initializing');
-          showStatusMessage('Wallet syncing...', 'info');
-          navigate('/dashboard');
-        } else {
-          setError(msg.error ?? 'Failed to create wallet');
+        if (msg.type === 'WALLET_ADDED') {
+          setCreating(false);
+          if (msg.success) {
+            setSeedWords([]);
+            setSeedInput('');
+            usePopupStore.getState().setHasVault(true);
+            setStatus('initializing');
+            showStatusMessage('Wallet syncing...', 'info');
+            navigate('/dashboard');
+          } else {
+            setError(msg.error ?? 'Failed to create wallet');
+          }
+          port.disconnect();
         }
-        port.disconnect();
+        // Ignore other messages (STATE_UPDATE, DIAGNOSTIC_EVENT, etc.)
       });
     } catch (err) {
       setCreating(false);

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -53,6 +53,9 @@ export type PopupRequest =
       };
     }
   | { type: 'GET_WALLETS'; environment: Environment }
+  | { type: 'GET_ALL_WALLETS' }
+  | { type: 'DELETE_WALLET'; index: number }
+  | { type: 'GET_WALLET_SEED'; index: number }
   | { type: 'SEND_TRANSFER'; params: TransferRequest }
   | { type: 'DUST_REGISTER'; utxoIds: string[]; receiverAddress?: string }
   | { type: 'DUST_DEREGISTER'; utxoIds: string[] }
@@ -65,6 +68,14 @@ export type PopupResponse =
   | { type: 'STATE_UPDATE'; state: SerializedWalletState }
   | { type: 'WALLET_ADDED'; success: boolean; error?: string }
   | { type: 'WALLETS_LIST'; wallets: Array<{ index: number; name: string }> }
+  | {
+      type: 'ALL_WALLETS';
+      wallets: Record<Environment, Array<{ index: number; name: string }>>;
+      activeWalletIndex: number;
+      activeEnvironment: Environment;
+    }
+  | { type: 'WALLET_DELETED'; success: boolean; error?: string }
+  | { type: 'WALLET_SEED'; seedHex: string }
   | { type: 'TRANSFER_RESULT'; result: TransactionResult }
   | { type: 'DUST_REGISTER_RESULT'; result: TransactionResult }
   | { type: 'DUST_DEREGISTER_RESULT'; result: TransactionResult }

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -147,16 +147,18 @@ export async function saveSetting<T>(
 function sdkStateKey(
   environment: Environment,
   accountIndex: number,
+  walletId: string,
 ): string {
-  return `${environment}:${accountIndex}`;
+  return `${environment}:${accountIndex}:${walletId}`;
 }
 
 export async function getSdkState(
   environment: Environment,
   accountIndex: number,
+  walletId: string,
 ): Promise<PersistedSdkState | undefined> {
   const db = await getDb();
-  return db.get('sdkState', sdkStateKey(environment, accountIndex)) as
+  return db.get('sdkState', sdkStateKey(environment, accountIndex, walletId)) as
     Promise<PersistedSdkState | undefined>;
 }
 
@@ -170,9 +172,10 @@ export async function saveSdkState(
 export async function deleteSdkState(
   environment: Environment,
   accountIndex: number,
+  walletId: string,
 ): Promise<void> {
   const db = await getDb();
-  await db.delete('sdkState', sdkStateKey(environment, accountIndex));
+  await db.delete('sdkState', sdkStateKey(environment, accountIndex, walletId));
 }
 
 export async function deleteAllSdkState(): Promise<void> {


### PR DESCRIPTION
## Summary

- Unified wallet manager dropdown replacing network selector and wallet pickers
- Wallets grouped by network with create, switch, delete, and copy-seed actions
- SDK-aligned seed derivation (mnemonicToEntropy, per-role retry, seed wiping)
- Per-wallet checkpoint isolation prevents new wallets loading another wallet's sync state
- Dashboard layout: status bar with sync progress, 40/60 explorer/events split, compact balances
- Integration guide updated with Step 0 (mnemonic-to-seed) and per-role derivation pattern

## Test plan

- [ ] Open wallet menu — wallets grouped by network, counts correct
- [ ] Click wallet to switch — menu closes, wallet syncs
- [ ] Create new mainnet wallet — syncs from scratch (not from another wallet's checkpoint)
- [ ] Genesis W0-W3 buttons work, cannot be deleted
- [ ] Copy seed copies hex to clipboard
- [ ] Delete non-genesis wallet works
- [ ] Onboarding: environment must be selected before proceeding
- [ ] Build passes: `npm run build`