### PR TITLE
build(deps): bump vite and @types/chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "2.4.0",
     "@tailwindcss/postcss": "4.2.2",
-    "@types/chrome": "0.1.38",
+    "@types/chrome": "0.1.39",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.1",
@@ -42,7 +42,7 @@
     "postcss": "8.5.8",
     "tailwindcss": "4.2.2",
     "typescript": "6.0.2",
-    "vite": "8.0.3",
+    "vite": "8.0.4",
     "vite-plugin-wasm": "3.6.0",
     "vitest": "4.1.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1144,10 +1144,10 @@
     "@types/deep-eql" "*"
     assertion-error "^2.0.1"
 
-"@types/chrome@0.1.38":
-  version "0.1.38"
-  resolved "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.38.tgz"
-  integrity sha512-5aK4m9wZqoWAoB98aElESLm/5pXpqJnFWMNoiCs/XdPsXR6wNdVkJFSdQ9Wr4PnTuUrxD0SuNuDHh3EG5QeBzA==
+"@types/chrome@0.1.39":
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/@types/chrome/-/chrome-0.1.39.tgz#6b92145a57d684311caa7fc02feced58dc6c0811"
+  integrity sha512-AttzlXiLx2TSqmuJy8baP7YrOb8yyIM6V02dePrK/n1wRlhnu7Obd7GqUUVhje0hhkU7BaJuQmoFXRd5hWqdjQ==
   dependencies:
     "@types/filesystem" "*"
     "@types/har-format" "*"
@@ -1588,19 +1588,19 @@ expect-type@^1.3.0:
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
   integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
+fast-check@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-4.6.0.tgz#8b1238baf4e1152b4eeb9882f075463b48200e5b"
+  integrity sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==
+  dependencies:
+    pure-rand "^8.0.0"
+
 fast-check@^3.23.1:
   version "3.23.2"
   resolved "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz"
   integrity sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==
   dependencies:
     pure-rand "^6.1.0"
-
-fast-check@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/fast-check/-/fast-check-4.6.0.tgz#8b1238baf4e1152b4eeb9882f075463b48200e5b"
-  integrity sha512-h7H6Dm0Fy+H4ciQYFxFjXnXkzR2kr9Fb22c0UBpHnm59K2zpr2t13aPTHlltFiNT6zuxp6HMPAVVvgur4BLdpA==
-  dependencies:
-    pure-rand "^8.0.0"
 
 fast-glob@^3.2.11:
   version "3.3.3"
@@ -2171,17 +2171,17 @@ react-refresh@^0.13.0:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz"
   integrity sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==
 
-react-router-dom@7.13.2:
-  version "7.13.2"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz"
-  integrity sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==
+react-router-dom@7.14.0:
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.14.0.tgz#9d2df92ec9ce47e696808dc2a0e0a0c794ab278a"
+  integrity sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==
   dependencies:
-    react-router "7.13.2"
+    react-router "7.14.0"
 
-react-router@7.13.2:
-  version "7.13.2"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz"
-  integrity sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==
+react-router@7.14.0:
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.14.0.tgz#33169c9ac03b298bb51aad13e038ba548c79a862"
+  integrity sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==
   dependencies:
     cookie "^1.0.1"
     set-cookie-parser "^2.6.0"
@@ -2265,7 +2265,7 @@ rxjs@7.5.7:
   dependencies:
     tslib "^2.1.0"
 
-rxjs@7.8.2, rxjs@^7.8.1:
+rxjs@7.8.2, rxjs@^7.8.1, rxjs@^7.8.2:
   version "7.8.2"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz"
   integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
@@ -2419,10 +2419,10 @@ vite-plugin-wasm@3.6.0:
   resolved "https://registry.npmjs.org/vite-plugin-wasm/-/vite-plugin-wasm-3.6.0.tgz"
   integrity sha512-mL/QPziiIA4RAA6DkaZZzOstdwbW5jO4Vz7Zenj0wieKWBlNvIvX5L5ljum9lcUX0ShNfBgCNLKTjNkRVVqcsw==
 
-vite@8.0.3:
-  version "8.0.3"
-  resolved "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz"
-  integrity sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==
+vite@8.0.4:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.0.4.tgz#3e1d20c979dfa88386428c6b8c300b864ffd0449"
+  integrity sha512-baBr4jUVSLJ0RPyZ2nK0zS2+W8hNHbM4hEzfvllukmRPVS3xDG5ATTNtbRXrKIOE2b8/FsPWJAOnuIxcs7g3cw==
   dependencies:
     lightningcss "^1.32.0"
     picomatch "^4.0.4"
@@ -2445,7 +2445,7 @@ vite@8.0.3:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@^4.1.4:
+vitest@4.1.4:
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/vitest/-/vitest-4.1.4.tgz#330a3798ce307f88d3eea373e61a5f14da8f3bb1"
   integrity sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==


### PR DESCRIPTION
## Summary
- Bump `vite` 8.0.3 → 8.0.4 (patch)
- Bump `@types/chrome` 0.1.38 → 0.1.39 (patch)

Supersedes #49 and #50 which had merge conflicts after dependency pinning in #54.

## Test plan
- [x] `yarn typecheck` — clean
- [x] `yarn test` — 107/107 pass
- [x] `yarn build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)